### PR TITLE
fix: oauth unlinking error

### DIFF
--- a/lib/components/channel_panel.dart
+++ b/lib/components/channel_panel.dart
@@ -257,23 +257,22 @@ class _ChannelPanelWidgetState extends State<ChannelPanelWidget> {
 
   Widget _buildEmotePicker(BuildContext context) {
     var channelProvider = Provider.of<ChannelsModel>(context, listen: false);
-    return channelProvider.subscribedChannels.isNotEmpty
-        ? Offstage(
-            child: EmotePickerWidget(
-                channelId: channelProvider.subscribedChannels.first.channelId,
-                onDismiss: () => setState(() => _isEmotePickerVisible = false),
-                onDelete: () {
-                  var initialText = _textEditingController.text;
-                  if (initialText.isNotEmpty) {
-                    _textEditingController.text =
-                        initialText.substring(0, initialText.length - 1);
-                  }
-                },
-                onEmoteSelected: (emote) {
-                  _textEditingController.text =
-                      _textEditingController.text + " " + emote.code;
-                }),
-            offstage: !_isEmotePickerVisible)
+    return channelProvider.subscribedChannels.isNotEmpty &&
+            _isEmotePickerVisible
+        ? EmotePickerWidget(
+            channelId: channelProvider.subscribedChannels.first.channelId,
+            onDismiss: () => setState(() => _isEmotePickerVisible = false),
+            onDelete: () {
+              var initialText = _textEditingController.text;
+              if (initialText.isNotEmpty) {
+                _textEditingController.text =
+                    initialText.substring(0, initialText.length - 1);
+              }
+            },
+            onEmoteSelected: (emote) {
+              _textEditingController.text =
+                  _textEditingController.text + " " + emote.code;
+            })
         : Container();
   }
 }

--- a/lib/models/adapters/profiles.dart
+++ b/lib/models/adapters/profiles.dart
@@ -24,6 +24,7 @@ class ProfilesAdapter {
   Stream<Channel?> getChannel({required String userId}) {
     return db.collection("profiles").doc(userId).snapshots().map((event) {
       final data = event.data();
+      print(data);
       if (data != null && data.containsKey('twitch')) {
         return Channel(
             "twitch", data['twitch']['id'], data['twitch']['displayName']);

--- a/lib/models/adapters/profiles.dart
+++ b/lib/models/adapters/profiles.dart
@@ -21,12 +21,13 @@ class ProfilesAdapter {
   static ProfilesAdapter get instance =>
       ProfilesAdapter.instanceFor(db: FirebaseFirestore.instance);
 
-  Stream<Channel?> getChannel({required String userId}) {
+  Stream<Channel?> getChannel(
+      {required String userId, required String provider}) {
     return db.collection("profiles").doc(userId).snapshots().map((event) {
       final data = event.data();
-      if (data != null && data.containsKey('twitch')) {
+      if (data != null && data.containsKey(provider)) {
         return Channel(
-            "twitch", data['twitch']['id'], data['twitch']['displayName']);
+            provider, data['twitch']['id'], data['twitch']['displayName']);
       }
     });
   }

--- a/lib/models/adapters/profiles.dart
+++ b/lib/models/adapters/profiles.dart
@@ -24,7 +24,6 @@ class ProfilesAdapter {
   Stream<Channel?> getChannel({required String userId}) {
     return db.collection("profiles").doc(userId).snapshots().map((event) {
       final data = event.data();
-      print(data);
       if (data != null && data.containsKey('twitch')) {
         return Channel(
             "twitch", data['twitch']['id'], data['twitch']['displayName']);

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -9,7 +9,6 @@ import 'package:rtchat/models/channels.dart';
 import 'package:rxdart/rxdart.dart';
 
 class UserModel extends ChangeNotifier {
-  User? _user = FirebaseAuth.instance.currentUser;
   late final StreamSubscription<void> _subscription;
   Channel? _userChannel;
 
@@ -17,8 +16,6 @@ class UserModel extends ChangeNotifier {
     _subscription = FirebaseAuth.instance
         .authStateChanges()
         .doOnData((user) {
-          _user = user;
-          notifyListeners();
           FirebaseCrashlytics.instance.setUserIdentifier(user?.uid ?? "");
         })
         .switchMap((user) => user == null
@@ -36,7 +33,7 @@ class UserModel extends ChangeNotifier {
     super.dispose();
   }
 
-  bool isSignedIn() => _user != null;
+  bool isSignedIn() => _userChannel != null;
 
   Future<void> send(Channel channel, String message) async {
     final call = FirebaseFunctions.instance.httpsCallable('send');

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -23,13 +23,12 @@ class UserModel extends ChangeNotifier {
         .switchMap((user) => user == null
             ? Stream.value(null)
             : ProfilesAdapter.instance
-                .getChannel(userId: user.uid, provider: "twitch")
-                .doOnData((profile) {
-                if (profile == null) {
-                  FirebaseAuth.instance.signOut();
-                }
-              }))
+                .getChannel(userId: user.uid, provider: "twitch"))
         .listen((channel) {
+          if (_userChannel != null && channel == null) {
+            // we've lost channel data (likely invalid auth) so sign the user out.
+            FirebaseAuth.instance.signOut();
+          }
           _userChannel = channel;
           notifyListeners();
         });


### PR DESCRIPTION
This fixes the case when we no longer have an active refresh token, which may be due to the user changing their account credentials. The token will expire and we delete the profile data to sign the user out.