### PR TITLE
chore: remove hype train settings

### DIFF
--- a/lib/screens/settings/events.dart
+++ b/lib/screens/settings/events.dart
@@ -96,24 +96,6 @@ class EventsScreen extends StatelessWidget {
           Padding(
               padding: const EdgeInsets.all(16),
               child: StyleModelTheme(
-                  child: TwitchHypeTrainEventWidget(TwitchHypeTrainEventModel(
-                messageId: '',
-                timestamp: DateTime.now(),
-                goal: 500,
-                level: 2,
-                progress: 75,
-                total: 88,
-              )))),
-          ListTile(
-            title: const Text('Hypetrain event config'),
-            subtitle: const Text("Customize your hypetrain event"),
-            onTap: () {
-              Navigator.pushNamed(context, "/settings/events/hypetrain");
-            },
-          ),
-          Padding(
-              padding: const EdgeInsets.all(16),
-              child: StyleModelTheme(
                   child: TwitchPollEventWidget(TwitchPollEventModel(
                 messageId: '',
                 timestamp: DateTime.now(),

--- a/lib/screens/settings/events.dart
+++ b/lib/screens/settings/events.dart
@@ -2,14 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:rtchat/components/chat_history/twitch/cheer_event.dart';
 import 'package:rtchat/components/chat_history/twitch/follow_event.dart';
-import 'package:rtchat/components/chat_history/twitch/hype_train_event.dart';
 import 'package:rtchat/components/chat_history/twitch/poll_event.dart';
 import 'package:rtchat/components/chat_history/twitch/raid_event.dart';
 import 'package:rtchat/components/chat_history/twitch/subscription_event.dart';
 import 'package:rtchat/components/style_model_theme.dart';
 import 'package:rtchat/models/layout.dart';
 import 'package:rtchat/models/messages/twitch/event.dart';
-import 'package:rtchat/models/messages/twitch/hype_train_event.dart';
 import 'package:rtchat/models/messages/twitch/subscription_event.dart';
 import 'package:rtchat/models/messages/twitch/user.dart';
 


### PR DESCRIPTION
Removes the hype train settings items from the page.

I did not remove poll configuration as it is coming with #217.