### PR TITLE
fix: parse poll event timestamps

### DIFF
--- a/lib/models/messages/twitch/event.dart
+++ b/lib/models/messages/twitch/event.dart
@@ -93,8 +93,8 @@ class TwitchPollEventModel extends MessageModel {
         isCompleted: false,
         messageId: "poll${data['event']['id']}",
         timestamp: data['timestamp'].toDate(),
-        startTimestamp: data['event']['started_at'].toDate(),
-        endTimestamp: data['event']['ends_at'].toDate(),
+        startTimestamp: DateTime.parse(data['event']['started_at']),
+        endTimestamp: DateTime.parse(data['event']['ends_at']),
         status: 'ongoing');
     return m;
   }
@@ -110,8 +110,8 @@ class TwitchPollEventModel extends MessageModel {
         isCompleted: true,
         messageId: "poll${data['event']['id']}",
         timestamp: data['timestamp'].toDate(),
-        startTimestamp: data['event']['started_at'].toDate(),
-        endTimestamp: data['event']['ended_at'].toDate(),
+        startTimestamp: DateTime.parse(data['event']['started_at']),
+        endTimestamp: DateTime.parse(data['event']['ended_at']),
         status: data['event']['status']);
     return m;
   }


### PR DESCRIPTION
These fields are stored as [Strings](https://console.firebase.google.com/u/1/project/rtchat-47692/firestore/data/~2Fmessages~2Ftwitch:0mI1Rx5HgDL1gVGQhHRAlNYc9HSKNzIKMpPnWSNXddo%3D): ends_at: "2021-08-15T04:48:09.246733245Z"