### PR TITLE
fix: listen on all events for host

### DIFF
--- a/agent/src/agents/twitch.ts
+++ b/agent/src/agents/twitch.ts
@@ -1,6 +1,7 @@
 import * as admin from "firebase-admin";
 import TwitchJs, {
   Chat,
+  ChatEvents,
   PrivateMessage,
   PrivateMessageWithBits,
 } from "twitch-js";
@@ -79,7 +80,6 @@ async function addHost(
   timestamp: Date,
   viewers: number
 ) {
-  log.debug({ channel, displayName, viewers }, "adding host");
   const profile = await firebase.getProfile(channel.replace("#", ""));
   if (!profile) {
     log.error({ channel, displayName, viewers }, "no profile for host");
@@ -182,34 +182,16 @@ async function getChatAgent(
     );
   });
 
-  twitch.chat.on(TwitchJs.Chat.Events.HOSTED_WITH_VIEWERS, (message) => {
-    addHost(
-      firebase,
-      message.channel,
-      message.tags.displayName,
-      message.timestamp,
-      message.numberOfViewers || 0
-    );
-  });
-
-  twitch.chat.on(TwitchJs.Chat.Events.HOSTED_AUTO, (message) => {
-    addHost(
-      firebase,
-      message.channel,
-      message.tags.displayName,
-      message.timestamp,
-      message.numberOfViewers || 0
-    );
-  });
-
-  twitch.chat.on(TwitchJs.Chat.Events.HOSTED_WITHOUT_VIEWERS, (message) => {
-    addHost(
-      firebase,
-      message.channel,
-      message.tags.displayName,
-      message.timestamp,
-      0
-    );
+  twitch.chat.on(TwitchJs.Chat.Events.ALL, (message) => {
+    if (message.event.startsWith("HOSTED/")) {
+      addHost(
+        firebase,
+        message.channel,
+        (message as any).tags.displayName,
+        message.timestamp,
+        (message as any).numberOfViewers || 0
+      );
+    }
   });
 
   await twitch.chat.connect();


### PR DESCRIPTION
This correctly generates the db event: https://console.firebase.google.com/u/0/project/rtchat-47692/firestore/data/~2Fmessages~2Ftwitch:host-2022-03-17T17:06:50.177Z

Turns out the event id that it was matching against wasn't correct :\