### PR TITLE
fix: allow auth for account with no email

### DIFF
--- a/functions/src/auth.ts
+++ b/functions/src/auth.ts
@@ -107,13 +107,17 @@ app.get("/auth/twitch/callback", async (req, res) => {
     .set({ twitch: JSON.stringify(results.token) }, { merge: true });
 
   // save the profile information too.
-  const twitchProfile = {
-    ...email ? email: {},
+  const twitchProfile : any = {
     id: users["data"][0]["id"],
     displayName: users["data"][0]["display_name"],
     login: users["data"][0]["login"],
     profilePictureUrl: users["data"][0]["profile_image_url"],
   };
+
+  if (email) {
+    // Twitch accounts can be verified by phone and have no email
+    twitchProfile.email = email;
+  }
 
   await admin
     .firestore()

--- a/functions/src/auth.ts
+++ b/functions/src/auth.ts
@@ -108,7 +108,7 @@ app.get("/auth/twitch/callback", async (req, res) => {
 
   // save the profile information too.
   const twitchProfile = {
-    email,
+    ...email ? email: {},
     id: users["data"][0]["id"],
     displayName: users["data"][0]["display_name"],
     login: users["data"][0]["login"],


### PR DESCRIPTION
Fixes #317 

This is if we want to allow signup without email.