### PR TITLE
fix: set global font family

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -273,10 +273,12 @@ class _AppState extends State<App> {
       child: MaterialApp(
         title: 'RealtimeChat',
         theme: ThemeData(
+          fontFamily: GoogleFonts.poppins().fontFamily,
           brightness: Brightness.light,
           primarySwatch: primarySwatch,
         ),
         darkTheme: ThemeData(
+          fontFamily: GoogleFonts.poppins().fontFamily,
           brightness: Brightness.dark,
           primarySwatch: primarySwatch,
           scaffoldBackgroundColor: Colors.black,


### PR DESCRIPTION
Only set a global font family instead of a complete theme.

There are a couple elements that are not using the theme so the font is not applied but I guess that can be resolved as part of the individual tasks we have for the new style (onboarding button and search box)