### PR TITLE
fix: badge alignment and padding

### DIFF
--- a/lib/components/chat_history/twitch/badge.dart
+++ b/lib/components/chat_history/twitch/badge.dart
@@ -21,13 +21,15 @@ class TwitchBadgeWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<TwitchBadgeModel>(builder: (context, model, child) {
       if (!model.isEnabled("$badge/$version")) {
-        return Container();
+        return const SizedBox();
       }
       final url = model.badgeSets["$badge/$version"]?["image_url_4x"];
       if (url == null) {
-        return Container();
+        return const SizedBox();
       }
-      return Image(image: NetworkImageWithRetry(url), height: height);
+      return Padding(
+          padding: const EdgeInsets.only(right: 5),
+          child: Image(image: NetworkImageWithRetry(url), height: height));
     });
   }
 }

--- a/lib/components/chat_history/twitch/message.dart
+++ b/lib/components/chat_history/twitch/message.dart
@@ -152,13 +152,11 @@ class TwitchMessageWidget extends StatelessWidget {
       // add badges.
       children.addAll(model.badges.map((badge) => WidgetSpan(
           alignment: PlaceholderAlignment.middle,
-          child: Padding(
-              padding: const EdgeInsets.only(right: 5),
-              child: TwitchBadgeWidget(
-                  channelId: model.tags['room-id'],
-                  badge: badge.key,
-                  version: badge.version,
-                  height: styleModel.fontSize)))));
+          child: TwitchBadgeWidget(
+              channelId: model.tags['room-id'],
+              badge: badge.key,
+              version: badge.version,
+              height: styleModel.fontSize))));
 
       // add author.
       if (contributors.contains(model.author.userId)) {


### PR DESCRIPTION
closes #216 

I found the badge alignment issue to occur when a message has both a badge that is enabled and a badge that is disabled in settings. 
![image](https://user-images.githubusercontent.com/40963146/167230076-1d02a7c1-5a2a-466f-aa4e-fa97a419d953.png)
In the example above, the first message should have the broadcaster and twitch prime badges, but the twitch prime badge is disabled in settings. 

By changing the disabled badge container to a sized box, the alignment issue is fixed. However, there is still padding for the disabled badge.
![image](https://user-images.githubusercontent.com/40963146/167230479-3001ce2d-6eb2-447b-a715-7f5ba725a5fe.png)
I added padding in the Twitch badge widget instead of the message widget to only add padding to an enabled widget.

This is my first time using Flutter and my first pull request on GitHub so feedback is welcome.