### PR TITLE
fix: track tts most recent message timestamp

### DIFF
--- a/lib/models/tts.dart
+++ b/lib/models/tts.dart
@@ -18,6 +18,8 @@ class TtsModel extends ChangeNotifier {
   var _pitch = 1.0;
   var _isEnabled = false;
   final Set<TwitchUserModel> _mutedUsers = {};
+  // this is used to ignore messages in the future.
+  var _lastMessageTime = DateTime.now();
 
   String getVocalization(MessageModel model) {
     if (model is TwitchMessageModel) {
@@ -64,6 +66,8 @@ class TtsModel extends ChangeNotifier {
       _queue.clear();
       _evictionTimer?.cancel();
       _evictionTimer = null;
+    } else {
+      _lastMessageTime = DateTime.now();
     }
     say(
         SystemMessageModel(
@@ -139,6 +143,14 @@ class TtsModel extends ChangeNotifier {
       if ((_isBotMuted && model.author.isBot) || model.isCommand) {
         return;
       }
+    }
+
+    // make sure the message is in the future.
+    if (model is! SystemMessageModel) {
+      if (model.timestamp.isBefore(_lastMessageTime)) {
+        return;
+      }
+      _lastMessageTime = model.timestamp;
     }
 
     final vocalization = getVocalization(model);

--- a/lib/models/tts.dart
+++ b/lib/models/tts.dart
@@ -18,7 +18,7 @@ class TtsModel extends ChangeNotifier {
   var _pitch = 1.0;
   var _isEnabled = false;
   final Set<TwitchUserModel> _mutedUsers = {};
-  // this is used to ignore messages in the future.
+  // this is used to ignore messages in the past.
   var _lastMessageTime = DateTime.now();
 
   String getVocalization(MessageModel model) {


### PR DESCRIPTION
Closes #358

This works by tracking the timestamp of the latest message and rejecting messages in the past.