### PR TITLE
fix: add tts icon tooltip

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -203,6 +203,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                   icon: Icon(ttsModel.enabled
                       ? Icons.record_voice_over
                       : Icons.voice_over_off),
+                  tooltip: 'Text to speech',
                   onPressed: () {
                     ttsModel.enabled = !ttsModel.enabled;
                   });


### PR DESCRIPTION
Adds a tooltip to the tts icon to make it consistent with the other icons in the appbar