### PR TITLE
fix: fix button at bottom of scroll

### DIFF
--- a/lib/components/chat_panel.dart
+++ b/lib/components/chat_panel.dart
@@ -206,6 +206,7 @@ class _ScrollToBottomWidgetState extends State<_ScrollToBottomWidget> {
       child: Center(
         child: ElevatedButton(
             onPressed: () {
+              updateScrollPosition();
               widget.controller.animateTo(0,
                   duration: const Duration(milliseconds: 200),
                   curve: Curves.easeInOut);


### PR DESCRIPTION
This bug occurs when a user when a user doesn't have enough messages to scroll. Follow these steps to reproduce:
1. Resize the activity panel to cover the top message
2. Scroll up
3. Resize the activity panel to show all messages

The scroll to bottom button persists and cannot be dismissed by tapping while it is at the bottom of the scroll.

Calling `updateScrollPosition()` when the button is pressed dismisses the button in this case.