### PR TITLE
fix: clamp resize overscroll

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -68,7 +68,8 @@ class _ResizableWidgetState extends State<ResizableWidget> {
               });
             },
             onVerticalDragEnd: (details) {
-              widget.onResizeHeight(_height);
+              widget.onResizeHeight(
+                  _height.clamp(57, MediaQuery.of(context).size.height - 300));
             },
             onVerticalDragUpdate: (details) {
               setState(() {
@@ -100,7 +101,8 @@ class _ResizableWidgetState extends State<ResizableWidget> {
               });
             },
             onHorizontalDragEnd: (details) {
-              widget.onResizeWidth(_width);
+              widget.onResizeWidth(
+                  _width.clamp(57, MediaQuery.of(context).size.width - 400));
             },
             onHorizontalDragUpdate: (details) {
               setState(() {


### PR DESCRIPTION
When resizing the activity feed, if you drag past the size bounds, you have to drag the same distance you over-dragged before it starts resizing in the other direction. Clamping the height/width values on drag end fixes this.