### PR TITLE
fix: incorrect message id reference in reply

### DIFF
--- a/agent/src/agents/twitch.ts
+++ b/agent/src/agents/twitch.ts
@@ -159,7 +159,7 @@ async function join(
       .map((badge) => badge.split("/") as [string, string]);
     const reply = tags["reply-parent-msg-id"]
       ? {
-          messageId: tags["reply-parent-msg-id"],
+          messageId: `twitch:${tags["reply-parent-msg-id"]}`,
           displayName: tags["reply-parent-display-name"],
           userLogin: tags["reply-parent-user-login"],
           userId: tags["reply-parent-user-id"],


### PR DESCRIPTION
Adds twitch prefix to message id for #305 