### PR TITLE
fix: default vips and mods to unpinned

### DIFF
--- a/lib/models/messages/twitch/message_configuration.dart
+++ b/lib/models/messages/twitch/message_configuration.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 class TwitchMessageConfig extends ChangeNotifier {
-  Duration modMessageDuration = const Duration(seconds: 6);
-  Duration vipMessageDuration = const Duration(seconds: 6);
+  Duration modMessageDuration = const Duration(seconds: 0);
+  Duration vipMessageDuration = const Duration(seconds: 0);
 
   setModMessageDuration(Duration duration) {
     modMessageDuration = duration;


### PR DESCRIPTION
For very large channels, the behavior is a bit confusing because apparently VIPs and mods send a lot of messages