### PR TITLE
fix: shorten button text

### DIFF
--- a/lib/screens/onboarding.dart
+++ b/lib/screens/onboarding.dart
@@ -53,7 +53,7 @@ class OnboardingScreen extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(horizontal: 64),
                       child: ElevatedButton(
                           child: const Text(
-                            "Continue without signing in",
+                            "Continue as Guest",
                             textAlign: TextAlign.center,
                           ),
                         onPressed: () async {


### PR DESCRIPTION
"Continue without Signing In" is a bit long and wraps on some screens.