### PR TITLE
fix: improve prediction event legibility

### DIFF
--- a/lib/components/chat_history/twitch/prediction_event.dart
+++ b/lib/components/chat_history/twitch/prediction_event.dart
@@ -57,7 +57,9 @@ class _TwitchOutcomeWidget extends StatelessWidget {
             child: LinearProgressIndicator(
               value: outcome.points / max(1, totalPoints),
               valueColor: AlwaysStoppedAnimation<Color>(outcome.widgetColor),
-              backgroundColor: outcome.widgetColor.shade200,
+              backgroundColor: Theme.of(context).brightness == Brightness.light
+                  ? outcome.widgetColor.shade200
+                  : outcome.widgetColor.shade900,
             ),
           ),
           Builder(builder: (context) {


### PR DESCRIPTION
Improves the legibility of prediction events in dark mode

Before:
<img width="245" alt="image" src="https://user-images.githubusercontent.com/40963146/170789386-4e4fa0fd-2c31-4676-b8ad-8a2bdce541e9.png">

After:
<img width="246" alt="image" src="https://user-images.githubusercontent.com/40963146/170789324-65981bd9-19fc-426c-b1a7-7e6d2d7b5c18.png">

