### PR TITLE
feat: match drawer and settings quicklink order

### DIFF
--- a/lib/components/drawer/quicklinks_listview.dart
+++ b/lib/components/drawer/quicklinks_listview.dart
@@ -31,7 +31,7 @@ class QuicklinksListView extends StatelessWidget {
     return Consumer<QuickLinksModel>(
         builder: (context, quickLinksModel, child) {
       return Column(
-        children: quickLinksModel.sources.reversed.map((source) {
+        children: quickLinksModel.sources.map((source) {
           return ListTile(
             leading: Icon(quickLinksIconsMap[source.icon] ?? Icons.link),
             title: FutureBuilder<String>(


### PR DESCRIPTION
Quick link list order now matches between those two pages. Since we allow
users to reorder the list, it should match in the drawer.