### PR TITLE
fix: close `Drawer` after changing channel

### DIFF
--- a/lib/components/drawer/sidebar.dart
+++ b/lib/components/drawer/sidebar.dart
@@ -26,6 +26,7 @@ class _DrawerHeader extends StatelessWidget {
                 if (model.activeChannel != userChannel) {
                   model.activeChannel = userChannel;
                 }
+                Navigator.of(context).pop();
               },
               child: Row(children: [
                 CircleAvatar(


### PR DESCRIPTION
Closing the drawer makes it more obvious to the user what the shortcut does.