### PR TITLE
fix: add type for prediction outcomes

### DIFF
--- a/lib/models/messages/twitch/prediction_event.dart
+++ b/lib/models/messages/twitch/prediction_event.dart
@@ -37,7 +37,8 @@ class TwitchPredictionEventModel extends MessageModel {
         title: data['event']['title'],
         status: "in_progress",
         endTime: DateTime.parse(data['event']['locks_at']),
-        outcomes: data['event']['outcomes'].map((outcome) {
+        outcomes: data['event']['outcomes']
+            .map<TwitchPredictionOutcomeModel>((outcome) {
           return TwitchPredictionOutcomeModel(
               outcome['id'],
               outcome['channel_points'] ?? 0,
@@ -54,7 +55,8 @@ class TwitchPredictionEventModel extends MessageModel {
         status: data['event']['status'],
         winningOutcomeId: data['event']['winning_outcome_id'],
         endTime: DateTime.parse(data['event']['ended_at']),
-        outcomes: data['event']['outcomes'].map((outcome) {
+        outcomes: data['event']['outcomes']
+            .map<TwitchPredictionOutcomeModel>((outcome) {
           return TwitchPredictionOutcomeModel(outcome['id'],
               outcome['channel_points'], outcome['color'], outcome['title']);
         }).toList());


### PR DESCRIPTION
Seems like sometimes we have errors with type inference: type
List<dynamic> is not a subtype of type
List<TwitchPredictionOutcomeModel>