### PR TITLE
feat: search channels in `Drawer`

### DIFF
--- a/lib/components/drawer/sidebar.dart
+++ b/lib/components/drawer/sidebar.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:rtchat/components/channel_search_bottom_sheet.dart';
 import 'package:rtchat/components/drawer/quicklinks_listview.dart';
 import 'package:rtchat/components/image/resilient_network_image.dart';
+import 'package:rtchat/models/adapters/actions.dart';
 import 'package:rtchat/models/audio.dart';
 import 'package:rtchat/models/channels.dart';
 import 'package:rtchat/models/layout.dart';
@@ -20,39 +22,95 @@ class _DrawerHeader extends StatelessWidget {
           final userChannel = model.userChannel;
           return DrawerHeader(
             margin: EdgeInsets.zero,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(10.0),
-              onTap: () {
-                if (model.activeChannel != userChannel) {
-                  model.activeChannel = userChannel;
-                }
-              },
-              child: Row(children: [
-                CircleAvatar(
-                  backgroundImage: userChannel != null
-                      ? ResilientNetworkImage(userChannel.profilePictureUrl)
-                      : null,
-                  backgroundColor: Colors.transparent,
+            child: Row(
+              children: [
+                Expanded(
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(10.0),
+                    onTap: () {
+                      if (model.activeChannel != userChannel) {
+                        model.activeChannel = userChannel;
+                      }
+                    },
+                    child: Row(children: [
+                      CircleAvatar(
+                        backgroundImage: userChannel != null
+                            ? ResilientNetworkImage(
+                                userChannel.profilePictureUrl)
+                            : null,
+                        backgroundColor: Colors.transparent,
+                      ),
+                      const SizedBox(width: 16),
+                      Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(userChannel?.displayName ?? "Not signed in",
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyText1
+                                  ?.copyWith(color: Colors.white)),
+                          const SizedBox(height: 8),
+                          Text("twitch.tv",
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyText2
+                                  ?.copyWith(color: Colors.white)),
+                        ],
+                      ),
+                    ]),
+                  ),
                 ),
-                const SizedBox(width: 16),
-                Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(userChannel?.displayName ?? "Not signed in",
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodyText1
-                            ?.copyWith(color: Colors.white)),
-                    const SizedBox(height: 8),
-                    Text("twitch.tv",
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodyText2
-                            ?.copyWith(color: Colors.white)),
-                  ],
+                VerticalDivider(
+                  width: 4,
+                  thickness: 2,
+                  indent: 16,
+                  endIndent: 16,
+                  color:
+                      Theme.of(context).colorScheme.onTertiary.withOpacity(0.1),
                 ),
-              ]),
+                IconButton(
+                  icon: const Icon(Icons.search),
+                  iconSize: 32,
+                  splashRadius: 24,
+                  tooltip: 'Search channels',
+                  color: Theme.of(context).colorScheme.onTertiary,
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    showModalBottomSheet<void>(
+                      context: context,
+                      isScrollControlled: true,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16.0),
+                      ),
+                      builder: (context) {
+                        return DraggableScrollableSheet(
+                          initialChildSize: 0.8,
+                          maxChildSize: 0.9,
+                          expand: false,
+                          builder: (context, controller) {
+                            return ChannelSearchBottomSheetWidget(
+                              onChannelSelect: (channel) {
+                                model.activeChannel = channel;
+                              },
+                              onRaid: userChannel == model.activeChannel &&
+                                      userChannel != null
+                                  ? (channel) {
+                                      ActionsAdapter.instance.send(
+                                        userChannel,
+                                        "/raid ${channel.displayName}",
+                                      );
+                                    }
+                                  : null,
+                              controller: controller,
+                            );
+                          },
+                        );
+                      },
+                    );
+                  },
+                ),
+              ],
             ),
           );
         }),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40963146/172497913-941aeb69-508d-42ea-8431-7787b59b97b3.png)
I'm not sure if the code I passed to `onChannelSelect:` and `onRaid:` is correct. It works but it doesn't follow the patterns used for the search cards in the onboarding and home screen appBar.