### PR TITLE
chore: wire link-preview-widget

### DIFF
--- a/lib/components/chat_history/twitch/message_link_preview.dart
+++ b/lib/components/chat_history/twitch/message_link_preview.dart
@@ -71,9 +71,19 @@ class _TwitchMessageLinkPreviewWidgetState
                 ? null
                 : Image(
                     image: ResilientNetworkImage(Uri.parse(data.imageUrl!))),
-            title: data.title == null ? null : Text(data.title!),
-            subtitle: data.description == null ? null : Text(data.description!),
-            isThreeLine: true,
+            title: data.title == null
+                ? null
+                : Text(
+                    data.title!,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+            subtitle: data.description == null
+                ? null
+                : Text(
+                    data.description!,
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 2,
+                  ),
           ),
         ));
   }


### PR DESCRIPTION
seems like re-renders still happen when you scroll up and down.

 when viewport changes, the preview card would re-render and would that be a concern?

<img width="316" alt="image" src="https://user-images.githubusercontent.com/39935368/174183991-448379b8-3d4c-43e6-9381-6adc00c54bde.png">