### PR TITLE
fix: add padding to bottom of viewer list

### DIFF
--- a/lib/components/drawer/end_drawer.dart
+++ b/lib/components/drawer/end_drawer.dart
@@ -217,7 +217,7 @@ class LeftDrawerWidgetState extends State<LeftDrawerWidget> {
                 ),
                 const SliverToBoxAdapter(
                   child: SafeArea(
-                    child: SizedBox(height: 16),
+                    child: SizedBox(height: 8),
                   ),
                 ),
               ],

--- a/lib/components/drawer/end_drawer.dart
+++ b/lib/components/drawer/end_drawer.dart
@@ -217,9 +217,7 @@ class LeftDrawerWidgetState extends State<LeftDrawerWidget> {
                 ),
                 const SliverToBoxAdapter(
                   child: SafeArea(
-                    child: SizedBox(
-                      height: 16,
-                    ),
+                    child: SizedBox(height: 16),
                   ),
                 ),
               ],

--- a/lib/components/drawer/end_drawer.dart
+++ b/lib/components/drawer/end_drawer.dart
@@ -215,6 +215,13 @@ class LeftDrawerWidgetState extends State<LeftDrawerWidget> {
                     addAutomaticKeepAlives: true,
                   ),
                 ),
+                const SliverToBoxAdapter(
+                  child: SafeArea(
+                    child: SizedBox(
+                      height: 16,
+                    ),
+                  ),
+                ),
               ],
             );
           }


### PR DESCRIPTION
Users at the bottom of the viewer list can be hidden by the phone's navigation bar