### PR TITLE
ci: install rosetta

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -39,6 +39,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1
       - run: |
+          /usr/sbin/softwareupdate --install-rosetta --agree-to-license
           keychain initialize
           app-store-connect fetch-signing-files $(xcode-project detect-bundle-id) --type IOS_APP_STORE --create
           keychain add-certificates


### PR DESCRIPTION
Looks like GitHub Actions uses M1 chipped computers sometimes now.