### PR TITLE
feat: swipe to open drawers

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -171,6 +171,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
           key: _scaffoldKey,
           drawer: Sidebar(channel: widget.channel),
           endDrawer: LeftDrawerWidget(channel: widget.channel),
+          drawerEdgeDragWidth: MediaQuery.of(context).size.width * 0.6,
           onDrawerChanged: (isOpened) =>
               FocusManager.instance.primaryFocus?.unfocus(),
           onEndDrawerChanged: (isOpened) =>


### PR DESCRIPTION
closes #499 
Swiping on the left two thirds of the screen opens the drawer and swiping on the right third opens the viewer list.