### PR TITLE
fix: fix viewer list padding

### DIFF
--- a/lib/components/drawer/end_drawer.dart
+++ b/lib/components/drawer/end_drawer.dart
@@ -181,7 +181,7 @@ class LeftDrawerWidgetState extends State<LeftDrawerWidget> {
                 if (filteredVipList.isNotEmpty) ...[
                   const SliverPadding(
                     padding: EdgeInsets.only(top: 8, left: 8),
-                    sliver: SliverTitleWidget(title: "Channel VIPs"),
+                    sliver: SliverTitleWidget(title: "Community VIPs"),
                   )
                 ],
                 SliverList(

--- a/lib/components/drawer/end_drawer.dart
+++ b/lib/components/drawer/end_drawer.dart
@@ -208,7 +208,6 @@ class LeftDrawerWidgetState extends State<LeftDrawerWidget> {
                       );
                     },
                     childCount: filteredViewerList.length,
-                    addAutomaticKeepAlives: true,
                   ),
                 ),
               ],

--- a/lib/components/drawer/end_drawer.dart
+++ b/lib/components/drawer/end_drawer.dart
@@ -128,35 +128,31 @@ class LeftDrawerWidgetState extends State<LeftDrawerWidget> {
           } else {
             return CustomScrollView(
               slivers: [
-                SliverAppBar(
-                    actions: <Widget>[Container()],
-                    //disable the drawer icon that appears on the right of the app bar
-                    flexibleSpace: FlexibleSpaceBar(
+                SliverPadding(
+                  padding: const EdgeInsets.only(top: 24),
+                  sliver: SliverAppBar(
+                      actions: const [SizedBox()],
+                      //disable the drawer icon that appears on the right of the app bar
                       centerTitle: false,
-                      titlePadding:
-                          const EdgeInsets.only(left: 32.0, top: 10.0),
-                      title: Text(
-                        'Search Viewers',
-                        style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                            fontSize: 25,
-                            color: Theme.of(context).colorScheme.onSurface),
+                      title: Padding(
+                        padding: const EdgeInsets.only(left: 16),
+                        child: Text(
+                          'Search Viewers',
+                          style: Theme.of(context)
+                              .textTheme
+                              .headlineSmall
+                              ?.copyWith(fontWeight: FontWeight.bold),
+                        ),
                       ),
-                    ),
-                    backgroundColor: Colors.transparent,
-                    automaticallyImplyLeading: false),
-                sliverSearchBarWidget,
-                SliverList(
-                  delegate: SliverChildListDelegate(
-                    const [
-                      SizedBox(
-                        height: 8,
-                      ),
-                    ],
-                  ),
+                      backgroundColor: Colors.transparent,
+                      automaticallyImplyLeading: false),
                 ),
+                sliverSearchBarWidget,
                 if (filteredBroadcasterList.isNotEmpty) ...[
-                  const SliverTitleWidget(title: "Broadcaster"),
+                  const SliverPadding(
+                    padding: EdgeInsets.only(top: 8),
+                    sliver: SliverTitleWidget(title: "Broadcaster"),
+                  ),
                 ],
                 SliverList(
                   delegate: SliverChildBuilderDelegate(
@@ -169,14 +165,14 @@ class LeftDrawerWidgetState extends State<LeftDrawerWidget> {
                 ),
                 if (filteredModeratorList.isNotEmpty) ...[
                   const SliverPadding(
-                      padding:
-                          EdgeInsets.symmetric(vertical: 7.0, horizontal: 0.0)),
-                  const SliverTitleWidget(title: "Moderators")
+                    padding: EdgeInsets.only(top: 8, left: 8),
+                    sliver: SliverTitleWidget(title: "Moderators"),
+                  )
                 ],
                 SliverList(
                   delegate: SliverChildBuilderDelegate(
                     (BuildContext context, int index) => Padding(
-                      padding: const EdgeInsets.only(left: 16),
+                      padding: const EdgeInsets.only(left: 24),
                       child: Text(filteredModeratorList[index]),
                     ),
                     childCount: filteredModeratorList.length,
@@ -184,14 +180,14 @@ class LeftDrawerWidgetState extends State<LeftDrawerWidget> {
                 ),
                 if (filteredVipList.isNotEmpty) ...[
                   const SliverPadding(
-                      padding:
-                          EdgeInsets.symmetric(vertical: 7.0, horizontal: 0.0)),
-                  const SliverTitleWidget(title: "Community VIPs")
+                    padding: EdgeInsets.only(top: 8, left: 8),
+                    sliver: SliverTitleWidget(title: "Channel VIPs"),
+                  )
                 ],
                 SliverList(
                   delegate: SliverChildBuilderDelegate(
                     (BuildContext context, int index) => Padding(
-                      padding: const EdgeInsets.only(left: 16),
+                      padding: const EdgeInsets.only(left: 24),
                       child: Text(filteredVipList[index]),
                     ),
                     childCount: filteredVipList.length,
@@ -199,25 +195,20 @@ class LeftDrawerWidgetState extends State<LeftDrawerWidget> {
                 ),
                 if (filteredViewerList.isNotEmpty) ...[
                   const SliverPadding(
-                      padding:
-                          EdgeInsets.symmetric(vertical: 7.0, horizontal: 0.0)),
-                  const SliverTitleWidget(title: "Viewers")
+                    padding: EdgeInsets.only(top: 8, left: 8),
+                    sliver: SliverTitleWidget(title: "Viewers"),
+                  )
                 ],
                 SliverList(
                   delegate: SliverChildBuilderDelegate(
                     (BuildContext context, int index) {
                       return Padding(
-                        padding: const EdgeInsets.only(left: 16),
+                        padding: const EdgeInsets.only(left: 24),
                         child: Text(filteredViewerList[index]),
                       );
                     },
                     childCount: filteredViewerList.length,
                     addAutomaticKeepAlives: true,
-                  ),
-                ),
-                const SliverToBoxAdapter(
-                  child: SafeArea(
-                    child: SizedBox(height: 8),
                   ),
                 ),
               ],

--- a/lib/components/drawer/sliver_search_bar.dart
+++ b/lib/components/drawer/sliver_search_bar.dart
@@ -11,7 +11,7 @@ class SliverSearchBarWidget extends StatelessWidget {
     return SliverList(
       delegate: SliverChildListDelegate([
         Padding(
-          padding: const EdgeInsets.fromLTRB(32, 24, 32, 8),
+          padding: const EdgeInsets.fromLTRB(24, 0, 24, 8),
           child: Center(
             child: Container(
               height: 50,


### PR DESCRIPTION
I incorrectly diagnosed what was causing the issue I attempted to fix in #512. The issue was caused by `SliverPadding` widgets without a sliver child. When scrolling to the bottom, they would collect at the top of the screen preventing the user from being able to scroll to the bottom of the list. Adding the `SliverTitleWidget` widget to the `SliverPadding` fixes this. I also adjusted the padding to better match the mock.

<img width="255" alt="image" src="https://user-images.githubusercontent.com/40963146/175380693-80b38ef6-6eba-4da9-b8c4-bccce5b98025.png">
