### PR TITLE
fix: only duck audio on iOS

### DIFF
--- a/lib/models/audio.dart
+++ b/lib/models/audio.dart
@@ -41,7 +41,7 @@ class AudioSource {
 class AudioModel extends ChangeNotifier {
   final List<AudioSource> _sources = [];
   late final Timer _speakerDisconnectTimer;
-  final _audioCache = AudioCache(duckAudio: Platform.isIOS ? true : false);
+  final _audioCache = AudioCache(duckAudio: Platform.isIOS);
 
   bool _isOnline = false;
   bool _isSettingsVisible = false;

--- a/lib/models/audio.dart
+++ b/lib/models/audio.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:core';
+import 'dart:io';
 
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
@@ -40,7 +41,7 @@ class AudioSource {
 class AudioModel extends ChangeNotifier {
   final List<AudioSource> _sources = [];
   late final Timer _speakerDisconnectTimer;
-  final _audioCache = AudioCache(duckAudio: true);
+  final _audioCache = AudioCache(duckAudio: Platform.isIOS ? true : false);
 
   bool _isOnline = false;
   bool _isSettingsVisible = false;


### PR DESCRIPTION
I was watching YouTube on my Android phone when the volume lowered. I realized I had rtchat open and it was caused by the periodic silent sound ducking the audio. The strange thing is that it didn't return to full volume after playing. Only after I closed rtchat did it return to full volume.