### PR TITLE
chore: reword link to user profile

### DIFF
--- a/lib/components/chat_history/message.dart
+++ b/lib/components/chat_history/message.dart
@@ -147,7 +147,7 @@ class ChatHistoryMessage extends StatelessWidget {
                                   leading: const Icon(Icons.link_outlined,
                                       color: Colors.blueAccent),
                                   title: Text(
-                                      'Link to ${m.author.displayName}\'s profile'),
+                                      'View ${m.author.displayName}\'s profile'),
                                   onTap: () {
                                     launchUrlString(
                                         "https://www.twitch.tv/${m.author.displayName}");


### PR DESCRIPTION
I believe this is a bit more clear, otherwise you could believe the app will copy the link to the clipboard?