### PR TITLE
style: remove radius from bottom of search sheet

### DIFF
--- a/lib/components/drawer/sidebar.dart
+++ b/lib/components/drawer/sidebar.dart
@@ -85,10 +85,8 @@ class _DrawerHeader extends StatelessWidget {
                         context: context,
                         isScrollControlled: true,
                         shape: const RoundedRectangleBorder(
-                          borderRadius: BorderRadius.only(
-                            topLeft: Radius.circular(16),
-                            topRight: Radius.circular(16),
-                          ),
+                          borderRadius:
+                              BorderRadius.vertical(top: Radius.circular(16)),
                         ),
                         builder: (context) {
                           return DraggableScrollableSheet(

--- a/lib/components/header_bar.dart
+++ b/lib/components/header_bar.dart
@@ -148,10 +148,7 @@ class _HeaderBarWidgetState extends State<HeaderBarWidget> {
                 context: context,
                 isScrollControlled: true,
                 shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.only(
-                    topLeft: Radius.circular(16),
-                    topRight: Radius.circular(16),
-                  ),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
                 ),
                 builder: (context) {
                   return DraggableScrollableSheet(

--- a/lib/screens/onboarding.dart
+++ b/lib/screens/onboarding.dart
@@ -104,10 +104,7 @@ class _LoginOptionsWidgetState extends State<LoginOptionsWidget> {
                 context: context,
                 isScrollControlled: true,
                 shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.only(
-                    topLeft: Radius.circular(16),
-                    topRight: Radius.circular(16),
-                  ),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
                 ),
                 builder: (context) {
                   return DraggableScrollableSheet(


### PR DESCRIPTION
On devices with square corners the bottom of the channel search sheet can look awkward.

![image](https://user-images.githubusercontent.com/40963146/176776342-70307397-1dd1-43d6-b3b1-16e8d1af77d0.png)
