### PR TITLE
fix: remove dashes

### DIFF
--- a/lib/models/tts.dart
+++ b/lib/models/tts.dart
@@ -110,7 +110,7 @@ class TtsModel extends ChangeNotifier {
     }
     say(
         SystemMessageModel(
-            text: "Text-to-speech ${value ? "enabled" : "disabled"}"),
+            text: "Text to speech ${value ? "enabled" : "disabled"}"),
         force: true);
     notifyListeners();
   }


### PR DESCRIPTION
In some languages (eg German), the dashes aren't read correctly. We should localize, but until then this is a decent solution.