### PR TITLE
fix: update emote picker colors for light mode

### DIFF
--- a/lib/components/emote_picker.dart
+++ b/lib/components/emote_picker.dart
@@ -42,7 +42,7 @@ class EmotesList extends StatelessWidget {
                   padding: const EdgeInsets.all(8.0),
                   child: Text(
                     categories[index],
-                    style: const TextStyle(color: Colors.white),
+                    style: TextStyle(color: Theme.of(context).colorScheme.primary),
                   )),
             ),
             content: Center(

--- a/lib/themes.dart
+++ b/lib/themes.dart
@@ -38,23 +38,23 @@ final primarySwatch = generateMaterialColor(accentColor);
 
 class Themes {
   static final lightTheme = ThemeData(
-    fontFamily: GoogleFonts.poppins().fontFamily,
-    brightness: Brightness.light,
-    colorScheme: ColorScheme.fromSwatch(
-      primarySwatch: primarySwatch,
-      accentColor: lightAccentColor,
-    ).copyWith(
-      primary: lightAccentColor,
-      secondary: lightAccentColor,
-      tertiary: detailColor,
-      background: Colors.white,
-    ),
-    toggleableActiveColor: lightAccentColor,
-    inputDecorationTheme: const InputDecorationTheme(
-      fillColor: lightTextFieldColor,
-    ),
-    appBarTheme: const AppBarTheme(color: detailColor),
-  );
+      fontFamily: GoogleFonts.poppins().fontFamily,
+      brightness: Brightness.light,
+      colorScheme: ColorScheme.fromSwatch(
+        primarySwatch: primarySwatch,
+        accentColor: lightAccentColor,
+      ).copyWith(
+        primary: lightAccentColor,
+        secondary: lightAccentColor,
+        tertiary: detailColor,
+        background: Colors.white,
+      ),
+      toggleableActiveColor: lightAccentColor,
+      inputDecorationTheme: const InputDecorationTheme(
+        fillColor: lightTextFieldColor,
+      ),
+      appBarTheme: const AppBarTheme(color: detailColor),
+      tabBarTheme: const TabBarTheme(labelColor: lightAccentColor));
 
   static final darkTheme = ThemeData(
     fontFamily: GoogleFonts.poppins().fontFamily,


### PR DESCRIPTION
Not completely sure these are the best but it's visible on light mode