### PR TITLE
fix: update field name of bit and channel point poll vote count

### DIFF
--- a/lib/models/messages/twitch/event.dart
+++ b/lib/models/messages/twitch/event.dart
@@ -134,8 +134,8 @@ class TwitchPollEventModel extends MessageModel {
       final String id = entry['id'];
       final String title = entry['title'] ?? "Untitled";
       final int votes = entry['votes'] ?? 0;
-      final int bitVotes = entry['bit_votes'] ?? 0;
-      final int channelPointVotes = entry['channel_point_votes'] ?? 0;
+      final int bitVotes = entry['bits_votes'] ?? 0;
+      final int channelPointVotes = entry['channel_points_votes'] ?? 0;
 
       var poll = PollChoiceModel(
           id: id,


### PR DESCRIPTION
https://dev.twitch.tv/docs/eventsub/eventsub-reference/#choices

Looks like bits can not be used for polls? I didn't remove it yet just in case.