### PR TITLE
fix: start rejecting invalid signatures

### DIFF
--- a/functions/src/eventsub.ts
+++ b/functions/src/eventsub.ts
@@ -105,9 +105,8 @@ export const eventsub = functions.https.onRequest(async (req, res) => {
     String(req.headers["twitch-eventsub-message-signature"]) !==
     `sha256=${signature}`
   ) {
-    console.error(new Error("failed to match signature"));
-    // res.status(403).send();
-    // return;
+    res.status(403).send();
+    return;
   }
   console.log("/eventsub", JSON.stringify(req.body));
 


### PR DESCRIPTION
We ignored invalid signatures for a long time because I accidentally changed the secret key. It's been long enough so we should prune off these subscriptions.