### PR TITLE
Revert "fix: start rejecting invalid signatures (#777)"

### DIFF
--- a/functions/src/eventsub.ts
+++ b/functions/src/eventsub.ts
@@ -105,8 +105,9 @@ export const eventsub = functions.https.onRequest(async (req, res) => {
     String(req.headers["twitch-eventsub-message-signature"]) !==
     `sha256=${signature}`
   ) {
-    res.status(403).send();
-    return;
+    console.error(new Error("failed to match signature"));
+    // res.status(403).send();
+    // return;
   }
   console.log("/eventsub", JSON.stringify(req.body));
 


### PR DESCRIPTION
Reverts muxable/rtchat#777

Maybe twitch doesn't delete invalid eventsubs as quickly as I had hoped.