### PR TITLE
fix: update search image stack to not clip promoted icon

### DIFF
--- a/lib/components/channel_search_results.dart
+++ b/lib/components/channel_search_results.dart
@@ -158,33 +158,39 @@ class _ChannelSearchResultsWidgetState
                               width: 2.0,
                             ),
                           ),
-                          child: Stack(alignment: Alignment.center, children: [
-                            ClipRRect(
-                              borderRadius: BorderRadius.circular(24),
-                              child: FadeInImage(
-                                  placeholder: MemoryImage(kTransparentImage),
-                                  image: ResilientNetworkImage(result.imageUrl),
-                                  height: 48,
-                                  width: 48),
-                            ),
-                            Positioned(
-                                right: -4,
-                                bottom: -4,
-                                child: result.isPromoted
-                                    ? Container(
-                                        decoration: BoxDecoration(
-                                          color: Theme.of(context).primaryColor,
-                                          borderRadius:
-                                              BorderRadius.circular(18.0),
-                                        ),
-                                        child: const Icon(
-                                          Icons.keyboard_double_arrow_up,
-                                          color: Colors.green,
-                                          size: 18.0,
-                                        ),
-                                      )
-                                    : Container())
-                          ])),
+                          child: Stack(
+                              alignment: Alignment.center,
+                              clipBehavior: Clip.none,
+                              children: [
+                                ClipRRect(
+                                  borderRadius: BorderRadius.circular(24),
+                                  child: FadeInImage(
+                                      placeholder:
+                                          MemoryImage(kTransparentImage),
+                                      image: ResilientNetworkImage(
+                                          result.imageUrl),
+                                      height: 48,
+                                      width: 48),
+                                ),
+                                Positioned(
+                                    right: -4,
+                                    bottom: -4,
+                                    child: result.isPromoted
+                                        ? Container(
+                                            decoration: BoxDecoration(
+                                              color: Theme.of(context)
+                                                  .primaryColor,
+                                              borderRadius:
+                                                  BorderRadius.circular(18.0),
+                                            ),
+                                            child: const Icon(
+                                              Icons.keyboard_double_arrow_up,
+                                              color: Colors.green,
+                                              size: 18.0,
+                                            ),
+                                          )
+                                        : Container())
+                              ])),
                       title: Text(result.displayName),
                       subtitle: Text(result.title),
                       onTap: () {


### PR DESCRIPTION
The problem is more relevant on light mode.