### PR TITLE
fix: use tap for quicklink tooltip since longpress conflicts with reorderlistview

### DIFF
--- a/lib/screens/settings/quick_links.dart
+++ b/lib/screens/settings/quick_links.dart
@@ -71,6 +71,7 @@ class _QuickLinksScreenState extends State<QuickLinksScreen> {
                   key: ValueKey(source),
                   background: const DismissibleDeleteBackground(),
                   child: Tooltip(
+                      triggerMode: TooltipTriggerMode.tap,
                       message: "Swipe left or right to delete quick link",
                       child: ListTile(
                         key: ValueKey(source),


### PR DESCRIPTION
This makes both things work but I feel like it could be better to just add a '?' icon on the top right explaining the gestures instead of the tooltip?