### PR TITLE
fix: message input overflow when divider is drag too far

### DIFF
--- a/lib/components/chat_panel.dart
+++ b/lib/components/chat_panel.dart
@@ -176,7 +176,9 @@ class _ScrollToBottomWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnimatedPositioned(
       duration: const Duration(milliseconds: 300),
-      bottom: show ? 16 : -72,
+      bottom: show
+          ? 72 // 72 consideration for the InputField, since InputField is on top of the Stack.
+          : -72,
       curve: Curves.easeOut,
       child: Center(
         child: ElevatedButton(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -271,35 +271,49 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                   ),
                 );
                 if (orientation == Orientation.portrait) {
-                  return Column(children: [
-                    Consumer<LayoutModel>(
-                        builder: (context, layoutModel, child) {
-                      if (layoutModel.isShowNotifications) {
-                        return ResizableWidget(
-                            resizable: !layoutModel.locked,
-                            height: layoutModel.panelHeight,
-                            width: layoutModel.panelWidth,
-                            onResizeHeight: (height) {
-                              layoutModel.panelHeight = height;
-                            },
-                            onResizeWidth: (width) {
-                              layoutModel.panelWidth = width;
-                            },
-                            child: const ActivityFeedPanelWidget());
-                      } else if (layoutModel.isShowPreview) {
-                        return SizedBox(
-                            height: MediaQuery.of(context).size.width * 9 / 16,
-                            child: StreamPreview(channel: widget.channel));
-                      } else {
-                        return Container();
-                      }
-                    }),
-                    Expanded(
-                        child: DiscoWidget(
-                            isEnabled: widget.isDiscoModeEnabled,
-                            child: ChatPanelWidget(channel: widget.channel))),
-                    chatPanelFooter,
-                  ]);
+                  return Stack(
+                    children: [
+                      Column(
+                        children: [
+                          Consumer<LayoutModel>(
+                              builder: (context, layoutModel, child) {
+                            if (layoutModel.isShowNotifications) {
+                              return ResizableWidget(
+                                  resizable: !layoutModel.locked,
+                                  height: layoutModel.panelHeight,
+                                  width: layoutModel.panelWidth,
+                                  onResizeHeight: (height) {
+                                    layoutModel.panelHeight = height;
+                                  },
+                                  onResizeWidth: (width) {
+                                    layoutModel.panelWidth = width;
+                                  },
+                                  child: const ActivityFeedPanelWidget());
+                            } else if (layoutModel.isShowPreview) {
+                              return SizedBox(
+                                  height: MediaQuery.of(context).size.width *
+                                      9 /
+                                      16,
+                                  child:
+                                      StreamPreview(channel: widget.channel));
+                            } else {
+                              return Container();
+                            }
+                          }),
+                          Expanded(
+                              child: DiscoWidget(
+                                  isEnabled: widget.isDiscoModeEnabled,
+                                  child: ChatPanelWidget(
+                                      channel: widget.channel))),
+                        ],
+                      ),
+                      Positioned(
+                          left: 0,
+                          right: 0,
+                          bottom: MediaQuery.of(context).viewInsets.bottom,
+                          child: chatPanelFooter)
+                    ],
+                  );
                 } else {
                   // landscape
                   return Row(children: [


### PR DESCRIPTION
Closes #805

using `Stack` with `Positioned`, so that `InputField` is always on top of the keyboard

![image](https://user-images.githubusercontent.com/39935368/199459947-391b575a-3a0d-4738-b220-af22dd28ded3.png)
