### PR TITLE
fix: use login instead of twitch id to get viewer list

### DIFF
--- a/functions/src/chat-status.ts
+++ b/functions/src/chat-status.ts
@@ -196,7 +196,7 @@ export const getViewerList = functions.https.onCall(
           );
         }
         const chatters = await fetch(
-          `https://tmi.twitch.tv/group/user/${channel}/chatters`
+          `https://tmi.twitch.tv/group/user/${login}/chatters`
         );
         const chattersJson = await chatters.json();
         return chattersJson["chatters"];


### PR DESCRIPTION
Looks like we're passing twitch id instead of login.