### PR TITLE
fix: only release wakelock if held

### DIFF
--- a/android/app/src/main/kotlin/com/rtirl/chat/AudioService.kt
+++ b/android/app/src/main/kotlin/com/rtirl/chat/AudioService.kt
@@ -162,7 +162,9 @@ class AudioService : Service() {
             stopForeground(true)
             nm.cancel(NOTIFICATION_ID)
             stopSelf()
-            wakelock?.release()
+            if(wakelock?.isHeld() == true) {
+                wakelock?.release()
+            }
             START_NOT_STICKY
         }
     }


### PR DESCRIPTION
A RuntimException is thrown otherwise.