### PR TITLE
fix: expanded height size

### DIFF
--- a/lib/screens/settings/twitch/badges.dart
+++ b/lib/screens/settings/twitch/badges.dart
@@ -21,7 +21,7 @@ class TwitchBadgesScreen extends StatelessWidget {
           return CustomScrollView(slivers: <Widget>[
             SliverAppBar(
                 pinned: true,
-                expandedHeight: 250.0,
+                expandedHeight: 100.0,
                 flexibleSpace: FlexibleSpaceBar(
                   title: Text(AppLocalizations.of(context)!.twitchBadges),
                 ),


### PR DESCRIPTION
The current bar takes up too much space.
before:
![Simulator Screen Shot - iPhone 14 - 2023-01-28 at 06 31 54](https://user-images.githubusercontent.com/100245448/215272485-c3c5c510-20d1-41c1-b30b-76ac8cd982cf.png)
after:
![Simulator Screen Shot - iPhone 14 - 2023-01-28 at 06 32 13](https://user-images.githubusercontent.com/100245448/215272494-436733ef-d088-4e4f-b7f0-95cc6d564ff6.png)
