### PR TITLE
fix: badge settings visibility

### DIFF
--- a/lib/screens/settings/chat_history.dart
+++ b/lib/screens/settings/chat_history.dart
@@ -124,6 +124,7 @@ class ChatHistoryScreen extends StatelessWidget {
             ListTile(
               title: const Text('Twitch badge settings'),
               subtitle: const Text("Control which badges are visible"),
+              trailing: const Icon( Icons.arrow_forward_ios),
               onTap: () {
                 Navigator.pushNamed(context, "/settings/badges");
               },

--- a/lib/screens/settings/chat_history.dart
+++ b/lib/screens/settings/chat_history.dart
@@ -124,7 +124,7 @@ class ChatHistoryScreen extends StatelessWidget {
             ListTile(
               title: const Text('Twitch badge settings'),
               subtitle: const Text("Control which badges are visible"),
-              trailing: const Icon( Icons.arrow_forward_ios),
+              trailing: const Icon(Icons.arrow_forward_ios),
               onTap: () {
                 Navigator.pushNamed(context, "/settings/badges");
               },


### PR DESCRIPTION
Might help people find the setting.
before:
![Simulator Screen Shot - iPhone 14 - 2023-01-29 at 07 49 59](https://user-images.githubusercontent.com/100245448/215338352-43b60db1-1ae9-4868-9005-f950229222ae.png)
after:
![Simulator Screen Shot - iPhone 14 - 2023-01-29 at 07 50 52](https://user-images.githubusercontent.com/100245448/215338360-b0f77099-a84f-44c1-bee7-283fdf1ff568.png)
