### PR TITLE
fix: render only the display name

### DIFF
--- a/lib/components/channel_search_results.dart
+++ b/lib/components/channel_search_results.dart
@@ -214,11 +214,7 @@ class _ChannelSearchResultsWidgetState
                       title: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            result.displayName.toLowerCase() ==
-                                    result.login.toLowerCase()
-                                ? Text(result.displayName)
-                                : Text(
-                                    "${result.displayName} (${result.login})"),
+                            Text(result.displayName),
                             Text(result.language ?? "??",
                                 style: const TextStyle(
                                   fontSize: 12,


### PR DESCRIPTION
This rolls back the rendering part of #923