### PR TITLE
fix: properly access fields from search/channels response

### DIFF
--- a/functions/src/search.ts
+++ b/functions/src/search.ts
@@ -69,14 +69,13 @@ export const search = functions.https.onCall(async (data, context) => {
       return {
         provider: "twitch",
         channelId: channel.id,
-        login: channel.login,
+        login: channel.broadcaster_login,
         displayName: channel.display_name,
         isOnline: channel.is_live,
         imageUrl: channel.thumbnail_url,
         categoryName: channel.game_name,
         title: channel.title,
-        viewerCount: channel.viewer_count,
-        language: channel.language,
+        language: channel.broadcaster_language,
       };
     }),
   ];


### PR DESCRIPTION
We were accessing the response as if it was exactly as a `/streams/followed` call.

Example response:
```bash
$ twitch api get search/channels -q query=muxfd
{
  "data": [
    {
      "broadcaster_language": "en",
      "broadcaster_login": "murfdawgg",
      "display_name": "Murfdawgg",
      "game_id": "0",
      "game_name": "",
      "id": "20060690",
      "is_live": false,
      "started_at": "",
      "tag_ids": [],
      "tags": [],
      "thumbnail_url": "https://static-cdn.jtvnw.net/jtv_user_pictures/murfdawgg-profile_image-bd7db3e49d25d042-300x300.png",
      "title": ""
    },
    {
      "broadcaster_language": "",
      "broadcaster_login": "muxfede10",
      "display_name": "muxfede10",
      "game_id": "0",
      "game_name": "cs go",
      "id": "29855675",
      "is_live": false,
      "started_at": "",
      "tag_ids": [],
      "tags": [],
      "thumbnail_url": "https://static-cdn.jtvnw.net/user-default-pictures-uv/75305d54-c7cc-40d1-bb9c-91fbe85943c7-profile_image-300x300.png",
      "title": ""
    }, 
    ...
    ]
}
```