### PR TITLE
chore: replaced textlink shoutout with eventsub shoutout in inbound raid

### DIFF
--- a/lib/components/chat_history/twitch/raid_event.dart
+++ b/lib/components/chat_history/twitch/raid_event.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:provider/provider.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/components/image/resilient_network_image.dart';
 import 'package:rtchat/models/adapters/actions.dart';
 import 'package:rtchat/models/channels.dart';
 import 'package:rtchat/models/messages/twitch/event.dart';
-import 'package:rtchat/models/messages/twitch/eventsub_configuration.dart';
 
 class TwitchRaidEventWidget extends StatelessWidget {
   final TwitchRaidEventModel model;
@@ -36,23 +34,18 @@ class TwitchRaidEventWidget extends StatelessWidget {
             ],
           )),
         ),
-        Consumer<EventSubConfigurationModel>(
-            builder: (context, eventSubConfigurationModel, child) {
-          if (!eventSubConfigurationModel
-              .raidEventConfig.enableShoutoutButton) {
-            return Container();
-          }
-          return GestureDetector(
-              child: Text.rich(TextSpan(
-                  text: "Shoutout",
-                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      color:
-                          Theme.of(context).buttonTheme.colorScheme?.primary))),
-              onTap: () {
-                ActionsAdapter.instance
-                    .send(channel, "https://twitch.tv/${model.from.login}");
-              });
-        }),
+        GestureDetector(
+          onTap: () {
+            ActionsAdapter.instance
+                .send(channel, "https://twitch.tv/${model.from.login}");
+            ActionsAdapter.instance
+                .send(channel, "/shoutout ${model.from.login}");
+          },
+          child: Text.rich(TextSpan(
+              text: "Shoutout",
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  color: Theme.of(context).buttonTheme.colorScheme?.primary))),
+        )
       ]),
     );
   }

--- a/lib/components/chat_history/twitch/raid_event.dart
+++ b/lib/components/chat_history/twitch/raid_event.dart
@@ -50,8 +50,6 @@ class TwitchRaidEventWidget extends StatelessWidget {
                           Theme.of(context).buttonTheme.colorScheme?.primary))),
               onTap: () {
                 ActionsAdapter.instance
-                    .send(channel, "https://twitch.tv/${model.from.login}");
-                ActionsAdapter.instance
                     .send(channel, "/shoutout ${model.from.login}");
               });
         }),

--- a/lib/components/chat_history/twitch/raid_event.dart
+++ b/lib/components/chat_history/twitch/raid_event.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/components/image/resilient_network_image.dart';
 import 'package:rtchat/models/adapters/actions.dart';
 import 'package:rtchat/models/channels.dart';
 import 'package:rtchat/models/messages/twitch/event.dart';
+import 'package:rtchat/models/messages/twitch/eventsub_configuration.dart';
 
 class TwitchRaidEventWidget extends StatelessWidget {
   final TwitchRaidEventModel model;
@@ -34,18 +36,25 @@ class TwitchRaidEventWidget extends StatelessWidget {
             ],
           )),
         ),
-        GestureDetector(
-          onTap: () {
-            ActionsAdapter.instance
-                .send(channel, "https://twitch.tv/${model.from.login}");
-            ActionsAdapter.instance
-                .send(channel, "/shoutout ${model.from.login}");
-          },
-          child: Text.rich(TextSpan(
-              text: "Shoutout",
-              style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  color: Theme.of(context).buttonTheme.colorScheme?.primary))),
-        )
+        Consumer<EventSubConfigurationModel>(
+            builder: (context, eventSubConfigurationModel, child) {
+          if (!eventSubConfigurationModel
+              .raidEventConfig.enableShoutoutButton) {
+            return Container();
+          }
+          return GestureDetector(
+              child: Text.rich(TextSpan(
+                  text: "Shoutout",
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color:
+                          Theme.of(context).buttonTheme.colorScheme?.primary))),
+              onTap: () {
+                ActionsAdapter.instance
+                    .send(channel, "https://twitch.tv/${model.from.login}");
+                ActionsAdapter.instance
+                    .send(channel, "/shoutout ${model.from.login}");
+              });
+        }),
       ]),
     );
   }


### PR DESCRIPTION
Closes #918

its already implemented but ig we can trigger the eventsub with the text `/shoutout <streamer>`