### PR TITLE
fix: tier 3 color contrast

### DIFF
--- a/lib/components/chat_history/twitch/subscription_event.dart
+++ b/lib/components/chat_history/twitch/subscription_event.dart
@@ -76,7 +76,7 @@ class TwitchSubscriptionMessageEventWidget extends StatelessWidget {
     if (tier == '2000') {
       return const Color(0xFFD2D2E6);
     } else if (tier == '3000') {
-      return const Color(0xFFFFEA00);
+      return const Color(0xFFC09C39);
     } else {
       return Theme.of(context).colorScheme.secondary;
     }


### PR DESCRIPTION
The current one in discord is kinda bright https://discord.com/channels/823598483255722056/845327843659218944/1079900121250140232 this might look better. My other color I could use is #B0954B but that pushes into the brown colors.