### PR TITLE
fix: tier 2 color contrast

### DIFF
--- a/lib/components/chat_history/twitch/subscription_event.dart
+++ b/lib/components/chat_history/twitch/subscription_event.dart
@@ -74,7 +74,7 @@ class TwitchSubscriptionMessageEventWidget extends StatelessWidget {
 
   Color chipBackgroundColor(BuildContext context, String tier) {
     if (tier == '2000') {
-      return const Color(0xFFD2D2E6);
+      return const Color(0xFF9A93A9);
     } else if (tier == '3000') {
       return const Color(0xFFFFEA00);
     } else {


### PR DESCRIPTION
This moves away from #D2D2E6 a gray to #9A93A9 more of a purple which provides more visibility against the white text.