### PR TITLE
fix: stream preview model used over async gap

### DIFF
--- a/lib/components/stream_preview.dart
+++ b/lib/components/stream_preview.dart
@@ -93,7 +93,6 @@ class _StreamPreviewState extends State<StreamPreview> {
       })
       ..setNavigationDelegate(NavigationDelegate(
         onPageFinished: (url) async {
-          final model = Provider.of<StreamPreviewModel>(context, listen: false);
           await _controller.runJavaScript(
               await rootBundle.loadString('assets/twitch-tunnel.js'));
           // wait a second for twitch to catch up.


### PR DESCRIPTION
https://console.firebase.google.com/u/0/project/rtchat-47692/crashlytics/app/android:com.rtirl.chat/issues/fbe29b8c363b11272522f3dac523469d?time=last-seven-days&sessionEventKey=64299AED00D30001749E953E28A7C2EB_1795948315917602999