### PR TITLE
fix: remove incorrect late final from activity feed

### DIFF
--- a/lib/screens/settings/activity_feed.dart
+++ b/lib/screens/settings/activity_feed.dart
@@ -81,7 +81,7 @@ class _ActivityFeedScreenState extends State<ActivityFeedScreen> {
       body: SafeArea(
         child: Consumer3<ActivityFeedModel, UserModel, LayoutModel>(builder:
             (context, activityFeedModel, userModel, layoutModel, child) {
-          late final Uri? uri;
+          Uri? uri;
 
           final channel = userModel.userChannel;
           if (activityFeedModel.isCustom) {


### PR DESCRIPTION
https://console.firebase.google.com/u/0/project/rtchat-47692/crashlytics/app/android:com.rtirl.chat/issues/a08b2039abed6de296ccabd0ab123f02?time=last-seven-days&versions=2.3.11%20(6953148)&sessionEventKey=64293F3F00AE00011CD8011F56221655_1795815388620009013