### PR TITLE
fix: remove deprecation

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -76,8 +76,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-2604378007164700~3555462703</string>
 </dict>


### PR DESCRIPTION
This has been fixed into the flutter engine and also avoids warnings in Xcode
https://developer.apple.com/documentation/uikit/uiapplication/1623026-statusbarorientation?language=objc