### PR TITLE
fix: removing listener from mounted check

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -171,14 +171,18 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       debugPrint("Post frame callback post executed");
       final model = Provider.of<AudioModel>(context, listen: false);
       final ttsModel = Provider.of<TtsModel>(context, listen: false);
+
+      NotificationsPlugin.listenToTTs(ttsModel);
+
+
       if (model.sources.isEmpty || (await AudioChannel.hasPermission())) {
         return;
       }
       if (mounted) {
         debugPrint("Conditions passed");
         model.showAudioPermissionDialog(context);
-        debugPrint("Directly calling listenToTTs");
-        NotificationsPlugin.listenToTTs(ttsModel);
+       
+        
       }
     });
   }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -174,15 +174,12 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
       NotificationsPlugin.listenToTTs(ttsModel);
 
-
       if (model.sources.isEmpty || (await AudioChannel.hasPermission())) {
         return;
       }
       if (mounted) {
         debugPrint("Conditions passed");
         model.showAudioPermissionDialog(context);
-       
-        
       }
     });
   }


### PR DESCRIPTION
- I moved the function to listen to TTS above this line ` if (model.sources.isEmpty || (await AudioChannel.hasPermission())) {
        return;
      }` because the function may not always be reached . 