### PR TITLE
fix: upgrade node version

### DIFF
--- a/.github/workflows/firebase-functions-pull-request.yml
+++ b/.github/workflows/firebase-functions-pull-request.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: npm ci && npm run build
         working-directory: functions


### PR DESCRIPTION
This commit removed it just for the main branch https://github.com/muxable/rtchat/commit/6d44dce62d5bc3c91a23b618025b1c87fe3e18a4 so now on this run https://github.com/muxable/rtchat/actions/runs/8989985585/job/24694274860 it tells me the minimum supported version is 18