### PR TITLE
fix: sub event wording

### DIFF
--- a/lib/components/chat_history/twitch/subscription_event.dart
+++ b/lib/components/chat_history/twitch/subscription_event.dart
@@ -35,7 +35,7 @@ class TwitchSubscriptionEventWidget extends StatelessWidget {
             TextSpan(
                 text: model.subscriberUserName,
                 style: Theme.of(context).textTheme.titleSmall),
-            const TextSpan(text: " subscribed "),
+            const TextSpan(text: " subscribed at "),
             TextSpan(
               text: "Tier ${model.tier.replaceAll("000", "")}",
               style: textTheme?.copyWith(color: tierColor(context, model.tier)),
@@ -142,7 +142,7 @@ class TwitchSubscriptionMessageEventWidget extends StatelessWidget {
               TextSpan(
                   text: model.subscriberUserName,
                   style: Theme.of(context).textTheme.titleSmall),
-              const TextSpan(text: " subscribed "),
+              const TextSpan(text: " subscribed at "),
               TextSpan(
                 text: "Tier ${model.tier.replaceAll("000", "")}",
                 style:


### PR DESCRIPTION
The wording on https://github.com/muxable/rtchat/commit/5bb09db9c2e31846add426963fffef813f60c30f with the change of where the position is slightly off

![IMG_2786 Medium](https://github.com/muxable/rtchat/assets/100245448/436f6c0b-2b0c-430d-b76a-f551f9eeb262)
