### PR TITLE
fix: flutter 3.22 deprecations

### DIFF
--- a/lib/components/auth/twitch.dart
+++ b/lib/components/auth/twitch.dart
@@ -45,7 +45,7 @@ class SignInWithTwitch extends StatelessWidget {
   Widget build(BuildContext context) {
     return ElevatedButton(
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.all(const Color(0xFF6441A5)),
+        backgroundColor: WidgetStateProperty.all(const Color(0xFF6441A5)),
       ),
       child: Text(AppLocalizations.of(context)!.signInWithTwitch,
           style: const TextStyle(

--- a/lib/screens/settings/tts.dart
+++ b/lib/screens/settings/tts.dart
@@ -116,9 +116,9 @@ class TextToSpeechScreen extends StatelessWidget {
                                       color: Theme.of(context).dividerColor),
                                 ).copyWith(
                                   foregroundColor:
-                                      MaterialStateProperty.resolveWith<Color>(
-                                    (Set<MaterialState> states) =>
-                                        states.contains(MaterialState.disabled)
+                                      WidgetStateProperty.resolveWith<Color>(
+                                    (Set<WidgetState> states) =>
+                                        states.contains(WidgetState.disabled)
                                             ? Theme.of(context)
                                                 .colorScheme
                                                 .onSurface

--- a/lib/themes.dart
+++ b/lib/themes.dart
@@ -6,7 +6,7 @@ class Themes {
     colorScheme: ColorScheme.fromSeed(
       seedColor: const Color(0xFF009FDF),
       tertiary: const Color(0xFF1D1D1F),
-      background: Colors.white,
+      surface: Colors.white,
       brightness: Brightness.light,
     ),
   );
@@ -16,7 +16,7 @@ class Themes {
     colorScheme: ColorScheme.fromSeed(
       seedColor: const Color(0xFF009FDF),
       tertiary: const Color(0xFF1D1D1F),
-      background: Colors.black,
+      surface: Colors.black,
       brightness: Brightness.dark,
     ),
   );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -545,10 +545,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   js:
     dependency: transitive
     description:
@@ -593,26 +593,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   linkify:
     dependency: "direct main"
     description:
@@ -657,10 +657,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   metadata_fetch:
     dependency: "direct main"
     description:
@@ -975,10 +975,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -1071,10 +1071,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   wakelock:
     dependency: "direct main"
     description:
@@ -1180,5 +1180,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.2.3 <4.0.0"
-  flutter: ">=3.16.6"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   google_fonts: ^4.0.4
   google_mobile_ads: ^4.0.0
   in_app_purchase: ^3.1.13
-  intl: ^0.18.1
+  intl: ^0.19.0
   just_audio: ^0.9.36
   linkify: ^5.0.0
   metadata_fetch: ^0.4.1


### PR DESCRIPTION
This PR does the following
- Upgrades intl to 0.19.0 as required by flutter 3.22
- Changes from MaterialState to WidgetState as introduced in 3.22 https://api.flutter.dev/flutter/material/MaterialState.html
- Changes background to surface https://api.flutter.dev/flutter/material/ColorScheme/background.html