### PR TITLE
fix: landscape qr

### DIFF
--- a/lib/screens/settings/qr.dart
+++ b/lib/screens/settings/qr.dart
@@ -11,8 +11,11 @@ class QRDisplay extends StatelessWidget {
   Widget build(BuildContext context) {
     final querySize = MediaQuery.of(context).size;
 
+    final isLandScape = querySize.width > querySize.height;
+
     return Consumer<UserModel>(builder: (context, userModel, child) {
       final userChannel = userModel.userChannel;
+
       final inviteLink =
           "https://www.twitch.tv/${userModel.userChannel?.displayName ?? ""}";
 
@@ -22,51 +25,56 @@ class QRDisplay extends StatelessWidget {
             onTap: () {
               qrModel.changeGradient();
             },
-            child: Column(
-              children: [
-                Container(
-                  height: querySize.height * 0.42,
-                  width: querySize.width * 0.85,
-                  padding: EdgeInsets.only(top: querySize.height * 0.01),
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(querySize.width * 0.06),
-                    color: Colors.white,
-                  ),
-                  child: Stack(
-                    alignment: Alignment
-                        .center, // This centers the CircleAvatar in the middle of the Stack
-                    children: [
-                      QrImageView(
-                        data: inviteLink,
-                        eyeStyle: const QrEyeStyle(
-                          eyeShape: QrEyeShape.square,
-                          color: Colors.black,
-                        ),
-                        dataModuleStyle: const QrDataModuleStyle(
-                          dataModuleShape: QrDataModuleShape.square,
-                          color: Colors.black,
-                        ),
-                      ),
-                      CircleAvatar(
-                        radius: 35,
-                        backgroundImage: userChannel?.profilePicture,
-                      ),
-                    ],
-                  ),
-                ),
-                Padding(
-                  padding: EdgeInsets.only(top: querySize.height * 0.01),
-                  child: Text(
-                    "/${userModel.userChannel?.displayName ?? ""}",
-                    overflow: TextOverflow.fade,
-                    style: const TextStyle(
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  Container(
+                    height: isLandScape
+                        ? querySize.height * 0.52
+                        : querySize.height * 0.42,
+                    width: querySize.width * 0.85,
+                    padding: EdgeInsets.only(top: querySize.height * 0.01),
+                    decoration: BoxDecoration(
+                      borderRadius:
+                          BorderRadius.circular(querySize.width * 0.06),
                       color: Colors.white,
-                      fontSize: 29,
-                      fontWeight: FontWeight.bold,
+                    ),
+                    child: Stack(
+                      alignment: Alignment
+                          .center, // This centers the CircleAvatar in the middle of the Stack
+                      children: [
+                        QrImageView(
+                          data: inviteLink,
+                          eyeStyle: const QrEyeStyle(
+                            eyeShape: QrEyeShape.square,
+                            color: Colors.black,
+                          ),
+                          dataModuleStyle: const QrDataModuleStyle(
+                            dataModuleShape: QrDataModuleShape.square,
+                            color: Colors.black,
+                          ),
+                        ),
+                        CircleAvatar(
+                          radius: isLandScape ? 20 : 35,
+                          backgroundImage: userChannel?.profilePicture,
+                        ),
+                      ],
                     ),
                   ),
-                ),
-              ],
+                  Padding(
+                    padding: EdgeInsets.only(top: querySize.height * 0.01),
+                    child: Text(
+                      "/${userModel.userChannel?.displayName ?? ""}",
+                      overflow: TextOverflow.fade,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 29,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           );
         },


### PR DESCRIPTION
This is to fix the qr code not working horizontally, it isn't quite perfect I think but I'll let you take a look at the following pictures.

The old qr:
Portrait - I like how the text is above the bottom navigation bar here.
![IMG_2915 Medium](https://github.com/muxable/rtchat/assets/100245448/1c345ec8-3c57-4658-873e-d372f4fb7f18)

Landscape - It overflow and the qr code doesn't work because the profile picture is way to big.
![IMG_2916 Medium](https://github.com/muxable/rtchat/assets/100245448/14fe0558-a736-4d69-8335-92ca6a174ef2)

The new qr:
Portrait - The text is now very low and behind the bottom navigation bar.
![IMG_2913 Medium](https://github.com/muxable/rtchat/assets/100245448/a4edec4d-5bf4-420f-be79-30e772925264)

Landscape - The qr now works but I think the text is a little big.
![IMG_2914 Medium](https://github.com/muxable/rtchat/assets/100245448/d88e08b3-fa7e-4ac9-854c-17c07039a995)

I like how the old portrait text was and kind of how it looked in landscape but the qr code didn't work, this new way works but I don't quite like the text. Maybe we make the text smaller in the new landscape ui matching the old way without having to scroll and being over the navigation bar in portrait mode. I think I am missing something though, let me know the best way to do this.
