### PR TITLE
fix: support muting bots in new TTS engine

### DIFF
--- a/lib/tts_isolate.dart
+++ b/lib/tts_isolate.dart
@@ -88,6 +88,10 @@ Future<void> isolateMain(
                     timestamp: messageData['timestamp'].toDate(),
                     deleted: false,
                     channelId: messageData['channelId']);
+                // Check if the message is from a bot and if bot messages should be muted
+                if (ttsModel.isBotMuted && messageModel.author.isBot) {
+                  return; // Skip vocalization for bot messages
+                }
                 final finalMessage = ttsModel.getVocalization(
                   messageModel,
                   includeAuthorPrelude: !ttsModel.isPreludeMuted,


### PR DESCRIPTION
Related to #1252

Implements bot message muting in the TTS engine within `lib/tts_isolate.dart` as per the issue requirements.

- Adds a check to determine if a message originates from a bot using the `isBotMuted` flag and the author's bot status before vocalization.
- Skips the vocalization process for messages identified as originating from bots, effectively muting them.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat/issues/1252?shareId=1deebb38-fb77-44bf-8432-4a0ac30b246d).