### PR TITLE
feat: localize hardcoded strings in settings events screen

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -512,7 +512,7 @@
     "description": "Text label for a one minute duration"
   },
   "durationTenMinutes": "10 minutes",
-  "@durationFifteenMinutes": {
+  "@durationTenMinutes": {
     "description": "Text label for a ten minute duration"
   },
   "durationOneHour": "1 hour",
@@ -536,47 +536,131 @@
     "description": "Text label for a one week duration"
   },
   "durationTwoWeeks": "2 weeks",
-  "@durationOneMonth": {
+  "@durationTwoWeeks": {
     "description": "Text label for a two week duration"
   },
   "durationOneSecondTimeoutPrompt": "Timeout for 1 second",
   "@durationOneSecondTimeoutPrompt": {
-    "descriptionTimeoutPrompt": "Button label to timeout for a one second duration"
+    "description": "Button label to timeout for a one second duration"
   },
   "durationOneMinuteTimeoutPrompt": "Timeout for 1 minute",
   "@durationOneMinuteTimeoutPrompt": {
-    "descriptionTimeoutPrompt": "Button label to timeout for a one minute duration"
+    "description": "Button label to timeout for a one minute duration"
   },
   "durationTenMinutesTimeoutPrompt": "Timeout for 10 minutes",
-  "@durationFifteenMinutesTimeoutPrompt": {
-    "descriptionTimeoutPrompt": "Button label to timeout for a ten minute duration"
+  "@durationTenMinutesTimeoutPrompt": {
+    "description": "Button label to timeout for a ten minute duration"
   },
   "durationOneHourTimeoutPrompt": "Timeout for 1 hour",
   "@durationOneHourTimeoutPrompt": {
-    "descriptionTimeoutPrompt": "Button label to timeout for a one hour duration"
+    "description": "Button label to timeout for a one hour duration"
   },
   "durationSixHoursTimeoutPrompt": "Timeout for 6 hours",
   "@durationSixHoursTimeoutPrompt": {
-    "descriptionTimeoutPrompt": "Button label to timeout for a six hour duration"
+    "description": "Button label to timeout for a six hour duration"
   },
   "durationOneDayTimeoutPrompt": "Timeout for 1 day",
   "@durationOneDayTimeoutPrompt": {
-    "descriptionTimeoutPrompt": "Button label to timeout for a one day duration"
+    "description": "Button label to timeout for a one day duration"
   },
   "durationTwoDaysTimeoutPrompt": "Timeout for 2 days",
   "@durationTwoDaysTimeoutPrompt": {
-    "descriptionTimeoutPrompt": "Button label to timeout for a two day duration"
+    "description": "Button label to timeout for a two day duration"
   },
   "durationOneWeekTimeoutPrompt": "Timeout for 1 week",
   "@durationOneWeekTimeoutPrompt": {
-    "descriptionTimeoutPrompt": "Button label to timeout for a one week duration"
+    "description": "Button label to timeout for a one week duration"
   },
   "durationTwoWeeksTimeoutPrompt": "Timeout for 2 weeks",
   "@durationTwoWeeksTimeoutPrompt": {
-    "descriptionTimeoutPrompt": "Button label to timeout for a two week duration"
+    "description": "Button label to timeout for a two week duration"
   },
   "errorFetchingViewerList": "We couldn't fetch the viewer list for this channel",
   "@errorFetchingViewerList": {
-      "descriptionErrorFetchingViewerList": "Error message if unable to fetch list"
+      "description": "Error message if unable to fetch list"
+  },
+  "eventsTitle": "Events",
+  "@eventsTitle": {
+    "description": "Title for the events settings screen"
+  },
+  "followEventConfigTitle": "Follow Event",
+  "@followEventConfigTitle": {
+    "description": "Title for the follow event configuration"
+  },
+  "customizeYourFollowEvent": "Customize your follow event",
+  "@customizeYourFollowEvent": {
+    "description": "Subtitle for the follow event configuration"
+  },
+  "subscribeEventConfigTitle": "Subscribe Event",
+  "@subscribeEventConfigTitle": {
+    "description": "Title for the subscribe event configuration"
+  },
+  "customizeYourSubscriptionEvent": "Customize your subscription event",
+  "@customizeYourSubscriptionEvent": {
+    "description": "Subtitle for the subscribe event configuration"
+  },
+  "cheerEventConfigTitle": "Cheer Event",
+  "@cheerEventConfigTitle": {
+    "description": "Title for the cheer event configuration"
+  },
+  "customizeYourCheerEvent": "Customize your cheer event",
+  "@customizeYourCheerEvent": {
+    "description": "Subtitle for the cheer event configuration"
+  },
+  "raidEventConfigTitle": "Raid Event",
+  "@raidEventConfigTitle": {
+    "description": "Title for the raid event configuration"
+  },
+  "customizeYourRaidEvent": "Customize your raid event",
+  "@customizeYourRaidEvent": {
+    "description": "Subtitle for the raid event configuration"
+  },
+  "hostEventConfigTitle": "Host Event",
+  "@hostEventConfigTitle": {
+    "description": "Title for the host event configuration"
+  },
+  "customizeYourHostEvent": "Customize your host event",
+  "@customizeYourHostEvent": {
+    "description": "Subtitle for the host event configuration"
+  },
+  "hypetrainEventConfigTitle": "Hypetrain Event",
+  "@hypetrainEventConfigTitle": {
+    "description": "Title for the hypetrain event configuration"
+  },
+  "customizeYourHypetrainEvent": "Customize your hypetrain event",
+  "@customizeYourHypetrainEvent": {
+    "description": "Subtitle for the hypetrain event configuration"
+  },
+  "pollEventConfigTitle": "Poll Event",
+  "@pollEventConfigTitle": {
+    "description": "Title for the poll event configuration"
+  },
+  "customizeYourPollEvent": "Customize your poll event",
+  "@customizeYourPollEvent": {
+    "description": "Subtitle for the poll event configuration"
+  },
+  "predictionEventConfigTitle": "Prediction Event",
+  "@predictionEventConfigTitle": {
+    "description": "Title for the prediction event configuration"
+  },
+  "customizeYourPredictionEvent": "Customize your prediction event",
+  "@customizeYourPredictionEvent": {
+    "description": "Subtitle for the prediction event configuration"
+  },
+  "channelPointRedemptionEventConfigTitle": "Channel Point Redemption Event",
+  "@channelPointRedemptionEventConfigTitle": {
+    "description": "Title for the channel point redemption event configuration"
+  },
+  "customizeYourChannelPointRedemptionEvent": "Customize your channel point redemption event",
+  "@customizeYourChannelPointRedemptionEvent": {
+    "description": "Subtitle for the channel point redemption event configuration"
+  },
+  "outgoingRaidEventConfigTitle": "Outgoing Raid Event",
+  "@outgoingRaidEventConfigTitle": {
+    "description": "Title for the outgoing raid event configuration"
+  },
+  "customizeYourOutgoingRaidEvent": "Customize your outgoing raid event",
+  "@customizeYourOutgoingRaidEvent": {
+    "description": "Subtitle for the outgoing raid event configuration"
   }
 }

--- a/lib/screens/settings/events.dart
+++ b/lib/screens/settings/events.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:rtchat/components/chat_history/twitch/channel_point_event.dart';
 import 'package:rtchat/components/chat_history/twitch/cheer_event.dart';
@@ -23,7 +24,6 @@ import 'package:rtchat/models/messages/twitch/subscription_event.dart';
 import 'package:rtchat/models/messages/twitch/subscription_gift_event.dart';
 import 'package:rtchat/models/messages/twitch/subscription_message_event.dart';
 import 'package:rtchat/models/messages/twitch/user.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class EventsScreen extends StatelessWidget {
   const EventsScreen({super.key});

--- a/lib/screens/settings/events.dart
+++ b/lib/screens/settings/events.dart
@@ -23,6 +23,7 @@ import 'package:rtchat/models/messages/twitch/subscription_event.dart';
 import 'package:rtchat/models/messages/twitch/subscription_gift_event.dart';
 import 'package:rtchat/models/messages/twitch/subscription_message_event.dart';
 import 'package:rtchat/models/messages/twitch/user.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class EventsScreen extends StatelessWidget {
   const EventsScreen({super.key});
@@ -31,7 +32,7 @@ class EventsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Events'),
+        title: Text(AppLocalizations.of(context)!.eventsTitle),
       ),
       body: Consumer<LayoutModel>(builder: (context, layoutModel, child) {
         final dateTime = DateTime.now();
@@ -52,8 +53,8 @@ class EventsScreen extends StatelessWidget {
                   timestamp: DateTime.now(),
                 )))),
             EventConfigListTile(
-              title: const Text('Follow event config'),
-              subtitle: const Text('Customize your follow event'),
+              title: Text(AppLocalizations.of(context)!.followEventConfigTitle),
+              subtitle: Text(AppLocalizations.of(context)!.customizeYourFollowEvent),
               routeName: '/settings/events/follow',
               child: Switch.adaptive(
                 value: eventSubConfig.followEventConfig.showEvent,
@@ -100,8 +101,8 @@ class EventsScreen extends StatelessWidget {
                   text: 'Thanks for the stream!',
                 )))),
             EventConfigListTile(
-              title: const Text('Subscribe event config'),
-              subtitle: const Text('Customize your subscription event'),
+              title: Text(AppLocalizations.of(context)!.subscribeEventConfigTitle),
+              subtitle: Text(AppLocalizations.of(context)!.customizeYourSubscriptionEvent),
               routeName: '/settings/events/subscription',
               child: Switch.adaptive(
                 value: eventSubConfig.subscriptionEventConfig.showEvent,
@@ -121,8 +122,8 @@ class EventsScreen extends StatelessWidget {
                   isAnonymous: false,
                 )))),
             EventConfigListTile(
-              title: const Text('Cheer event config'),
-              subtitle: const Text('Customize your cheer event'),
+              title: Text(AppLocalizations.of(context)!.cheerEventConfigTitle),
+              subtitle: Text(AppLocalizations.of(context)!.customizeYourCheerEvent),
               routeName: '/settings/events/cheer',
               child: Switch.adaptive(
                 value: eventSubConfig.cheerEventConfig.showEvent,
@@ -149,8 +150,8 @@ class EventsScreen extends StatelessWidget {
                           "muxfd",
                         )))),
             EventConfigListTile(
-              title: const Text('Raid event config'),
-              subtitle: const Text('Customize your raid event'),
+              title: Text(AppLocalizations.of(context)!.raidEventConfigTitle),
+              subtitle: Text(AppLocalizations.of(context)!.customizeYourRaidEvent),
               routeName: '/settings/events/raid',
               child: Switch.adaptive(
                 value: eventSubConfig.raidEventConfig.showEvent,
@@ -171,8 +172,8 @@ class EventsScreen extends StatelessWidget {
                   viewers: 5,
                 )))),
             EventConfigListTile(
-              title: const Text('Host event config'),
-              subtitle: const Text('Customize your host event'),
+              title: Text(AppLocalizations.of(context)!.hostEventConfigTitle),
+              subtitle: Text(AppLocalizations.of(context)!.customizeYourHostEvent),
               routeName: '/settings/events/host',
               child: Switch.adaptive(
                 value: eventSubConfig.hostEventConfig.showEvent,
@@ -194,8 +195,8 @@ class EventsScreen extends StatelessWidget {
                   endTimestamp: DateTime(2021),
                 )))),
             EventConfigListTile(
-              title: const Text('Hypetrain event config'),
-              subtitle: const Text('Customize your hypetrain event'),
+              title: Text(AppLocalizations.of(context)!.hypetrainEventConfigTitle),
+              subtitle: Text(AppLocalizations.of(context)!.customizeYourHypetrainEvent),
               routeName: '/settings/events/hypetrain',
               child: Switch.adaptive(
                 value: eventSubConfig.hypetrainEventConfig.showEvent,
@@ -229,8 +230,8 @@ class EventsScreen extends StatelessWidget {
                         endTimestamp: DateTime(2021),
                         status: 'placeholder')))),
             EventConfigListTile(
-              title: const Text('Poll event config'),
-              subtitle: const Text('Customize your poll event'),
+              title: Text(AppLocalizations.of(context)!.pollEventConfigTitle),
+              subtitle: Text(AppLocalizations.of(context)!.customizeYourPollEvent),
               routeName: '/settings/events/poll',
               child: Switch.adaptive(
                 value: eventSubConfig.pollEventConfig.showEvent,
@@ -255,8 +256,8 @@ class EventsScreen extends StatelessWidget {
                           'outcome2', 100, 'blue', 'Tails')
                     ])))),
             EventConfigListTile(
-              title: const Text('Prediction event config'),
-              subtitle: const Text('Customize your prediction event'),
+              title: Text(AppLocalizations.of(context)!.predictionEventConfigTitle),
+              subtitle: Text(AppLocalizations.of(context)!.customizeYourPredictionEvent),
               routeName: '/settings/events/prediction',
               child: Switch.adaptive(
                 value: eventSubConfig.predictionEventConfig.showEvent,
@@ -278,13 +279,11 @@ class EventsScreen extends StatelessWidget {
                   userInput: 'Infront of Topaz!',
                 )))),
             EventConfigListTile(
-              title: const Text('Channel point redemption event config'),
-              subtitle:
-                  const Text('Customize your channel point redemption event'),
+              title: Text(AppLocalizations.of(context)!.channelPointRedemptionEventConfigTitle),
+              subtitle: Text(AppLocalizations.of(context)!.customizeYourChannelPointRedemptionEvent),
               routeName: '/settings/events/channel-point',
               child: Switch.adaptive(
-                value:
-                    eventSubConfig.channelPointRedemptionEventConfig.showEvent,
+                value: eventSubConfig.channelPointRedemptionEventConfig.showEvent,
                 onChanged: (value) => eventSubConfig
                     .setChannelPointRedemptionEventShowable(value),
               ),
@@ -302,8 +301,8 @@ class EventsScreen extends StatelessWidget {
                       displayName: 'muxfd'),
                 )))),
             EventConfigListTile(
-              title: const Text('Outgoing raid event config'),
-              subtitle: const Text('Customize your outgoing raid event'),
+              title: Text(AppLocalizations.of(context)!.outgoingRaidEventConfigTitle),
+              subtitle: Text(AppLocalizations.of(context)!.customizeYourOutgoingRaidEvent),
               routeName: '/settings/events/raiding',
               child: Switch.adaptive(
                 value: eventSubConfig.raidingEventConfig.showEvent,


### PR DESCRIPTION
Localizes hardcoded strings in `lib/screens/settings/events.dart` and updates `lib/l10n/app_en.arb` with new entries for localization.

- Replaces hardcoded strings in `lib/screens/settings/events.dart` with references to `AppLocalizations` to support localization.
- Adds new entries for all the replaced strings in `lib/l10n/app_en.arb`, including titles and subtitles for event configurations like follow, subscribe, cheer, raid, host, hypetrain, poll, prediction, channel point redemption, and outgoing raid events.
- Ensures that the localization keys and their values in `app_en.arb` match the references added in the Dart code, facilitating future translations and maintaining consistency across the application.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat?shareId=c8b6d34b-57fb-46fe-afdb-4ddc5914703f).