### PR TITLE
refactor: convert hype train event to StyledText

### DIFF
--- a/lib/components/chat_history/twitch/hype_train_event.dart
+++ b/lib/components/chat_history/twitch/hype_train_event.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/models/messages/twitch/hype_train_event.dart';
+import 'package:styled_text/styled_text.dart';
 
 class TwitchHypeTrainEventWidget extends StatelessWidget {
   final TwitchHypeTrainEventModel model;
@@ -13,29 +14,23 @@ class TwitchHypeTrainEventWidget extends StatelessWidget {
       icon: Icons.train,
       child: Builder(builder: (context) {
         if (model.hasEnded) {
-          return Text.rich(
-            TextSpan(children: [
-              const TextSpan(text: "Hype Train level "),
-              TextSpan(
-                  text: model.level.toString(),
+          return StyledText(
+            text: 'Hype Train level <b>${model.level}</b> ' +
+                (model.isSuccessful ? 'succeeded! ' : 'was not successful. '),
+            tags: {
+              'b': StyledTextTag(
                   style: Theme.of(context).textTheme.titleSmall),
-              model.isSuccessful
-                  ? const TextSpan(text: " succeeded! ")
-                  : const TextSpan(text: " was not successful. "),
-            ]),
+            },
           );
         } else {
-          return Text.rich(TextSpan(
-            children: [
-              const TextSpan(text: "Hype Train level "),
-              TextSpan(
-                  text: model.level.toString(),
+          return StyledText(
+            text: 'Hype Train level <b>${model.level}</b> in progress! ' +
+                '${(model.progress * 100) ~/ model.goal}% completed!',
+            tags: {
+              'b': StyledTextTag(
                   style: Theme.of(context).textTheme.titleSmall),
-              const TextSpan(text: " in progress! "),
-              TextSpan(
-                  text: "${(model.progress * 100) ~/ model.goal}% completed!"),
-            ],
-          ));
+            },
+          );
         }
       }),
     );


### PR DESCRIPTION
Updates the text rendering in `TwitchHypeTrainEventWidget` to use `StyledText()` for a more flexible and maintainable approach to styling.

- Replaces `Text.rich()` with `StyledText()` for rendering text, aligning with the proposed resolution to utilize `StyledText()` for text styling.
- Utilizes tags within `StyledText()` to apply styles, specifically using the `<b>` tag to style certain text segments as bold, which is achieved through the `StyledTextTag` and leveraging the `Theme.of(context).textTheme.titleSmall` for styling.
- Maintains the original text content and structure, ensuring that the transition to `StyledText()` does not alter the message conveyed to the user.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat?shareId=3037cb7f-389e-4341-9241-855ffb989174).