### PR TITLE
refactor: convert channel point events to StyledText

### DIFF
--- a/lib/components/chat_history/twitch/channel_point_event.dart
+++ b/lib/components/chat_history/twitch/channel_point_event.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/models/messages/twitch/channel_point_redemption_event.dart';
+import 'package:styled_text/styled_text.dart';
 
 class TwitchChannelPointRedemptionEventWidget extends StatelessWidget {
   final TwitchChannelPointRedemptionEventModel model;
@@ -11,21 +12,11 @@ class TwitchChannelPointRedemptionEventWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return DecoratedEventWidget.icon(
       icon: model.icon,
-      child: Text.rich(
-        TextSpan(
-          children: [
-            TextSpan(
-                text: model.redeemerUsername,
-                style: Theme.of(context).textTheme.titleSmall),
-            const TextSpan(text: " redeemed "),
-            TextSpan(
-                text: "${model.rewardName} ",
-                style: Theme.of(context).textTheme.titleSmall),
-            TextSpan(
-                text:
-                    "for ${model.rewardCost} points. ${model.userInput ?? ''}"),
-          ],
-        ),
+      child: StyledText(
+        text: '<b>${model.redeemerUsername}</b> redeemed <b>${model.rewardName}</b> for ${model.rewardCost} points. ${model.userInput ?? ''}',
+        tags: {
+          'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
+        },
       ),
     );
   }

--- a/lib/components/chat_history/twitch/channel_point_event.dart
+++ b/lib/components/chat_history/twitch/channel_point_event.dart
@@ -13,7 +13,8 @@ class TwitchChannelPointRedemptionEventWidget extends StatelessWidget {
     return DecoratedEventWidget.icon(
       icon: model.icon,
       child: StyledText(
-        text: '<b>${model.redeemerUsername}</b> redeemed <b>${model.rewardName}</b> for ${model.rewardCost} points. ${model.userInput ?? ''}',
+        text:
+            '<b>${model.redeemerUsername}</b> redeemed <b>${model.rewardName}</b> for ${model.rewardCost} points. ${model.userInput ?? ''}',
         tags: {
           'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
         },

--- a/test/components/chat_history/twitch/channel_point_event_test.dart
+++ b/test/components/chat_history/twitch/channel_point_event_test.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:rtchat/components/chat_history/twitch/channel_point_event.dart';
 import 'package:rtchat/models/messages/twitch/channel_point_redemption_event.dart';
 import 'package:rtchat/models/style.dart';
+import 'package:styled_text/styled_text.dart';
 
 void main() {
   testWidgets(
@@ -19,10 +20,11 @@ void main() {
         userInput: null);
     await tester.pumpWidget(buildWidget(model));
 
-    final findText = find.byWidgetPredicate((Widget widget) =>
-        widget is RichText &&
-        widget.text.toPlainText() ==
-            'automux redeemed Sprint for 100 points. ');
+    final findText = find.byWidgetPredicate((Widget widget) {
+      return widget is StyledText &&
+          widget.text ==
+              '<b>automux</b> redeemed <b>Sprint</b> for 100 points. ';
+    });
 
     final findIcon = find.byIcon(Icons.done);
 
@@ -43,10 +45,11 @@ void main() {
         userInput: "user input Kappa");
     await tester.pumpWidget(buildWidget(model));
 
-    final findText = find.byWidgetPredicate((Widget widget) =>
-        widget is RichText &&
-        widget.text.toPlainText() ==
-            'automux redeemed WaTeER for 350 points. user input Kappa');
+    final findText = find.byWidgetPredicate((Widget widget) {
+      return widget is StyledText &&
+          widget.text ==
+              '<b>automux</b> redeemed <b>WaTeER</b> for 350 points. user input Kappa';
+    });
 
     final findIcon = find.byIcon(Icons.timer);
 


### PR DESCRIPTION
Upgrades the TwitchChannelPointRedemptionEventWidget to use `StyledText` for enhanced text styling.

- Replaces `Text.rich` with `StyledText` widget to allow for more complex text styling and formatting.
- Utilizes `StyledText` tags to apply text styles, specifically using the `<b>` tag to bold the redeemer's username and the reward name.
- Preserves the existing text styles by mapping them to the `StyledTextTag` with the style defined in the theme's `titleSmall`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat?shareId=e5a42171-15f2-496f-a8bb-38079fae1ecc).