### PR TITLE
feat: localize static strings in chat history components

### DIFF
--- a/lib/components/chat_history/auxiliary/realtimecash_donation.dart
+++ b/lib/components/chat_history/auxiliary/realtimecash_donation.dart
@@ -11,7 +11,6 @@ class RealtimeCashDonationEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.avatar(
       avatar: model.image,
       child: Column(
@@ -20,8 +19,10 @@ class RealtimeCashDonationEventWidget extends StatelessWidget {
           children: [
             StyledText(
               text: model.donor != null && model.donor!.isNotEmpty
-                  ? loc.realtimeCashDonationWithDonor(model.donor!, model.value.toString(), model.currency)
-                  : loc.realtimeCashDonationAnonymous(model.value.toString(), model.currency),
+                  ? AppLocalizations.of(context)!.realtimeCashDonationWithDonor(
+                      model.donor!, model.value.toString(), model.currency)
+                  : AppLocalizations.of(context)!.realtimeCashDonationAnonymous(
+                      model.value.toString(), model.currency),
               tags: {
                 'b': StyledTextTag(
                     style: Theme.of(context).textTheme.titleSmall),

--- a/lib/components/chat_history/auxiliary/realtimecash_donation.dart
+++ b/lib/components/chat_history/auxiliary/realtimecash_donation.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/models/messages/auxiliary/realtimecash.dart';
 import 'package:styled_text/styled_text.dart';
@@ -10,6 +11,7 @@ class RealtimeCashDonationEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.avatar(
       avatar: model.image,
       child: Column(
@@ -18,8 +20,8 @@ class RealtimeCashDonationEventWidget extends StatelessWidget {
           children: [
             StyledText(
               text: model.donor != null && model.donor!.isNotEmpty
-                  ? '<b>${model.donor}</b> donated <b>${model.value.toString()} ${model.currency}</b>. '
-                  : 'Anonymous donated <b>${model.value.toString()} ${model.currency}</b>. ',
+                  ? loc.realtimeCashDonationWithDonor(model.donor!, model.value.toString(), model.currency)
+                  : loc.realtimeCashDonationAnonymous(model.value.toString(), model.currency),
               tags: {
                 'b': StyledTextTag(
                     style: Theme.of(context).textTheme.titleSmall),

--- a/lib/components/chat_history/auxiliary/streamelements.dart
+++ b/lib/components/chat_history/auxiliary/streamelements.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/models/messages/auxiliary/streamelements.dart';
 import 'package:styled_text/styled_text.dart';
@@ -10,6 +11,7 @@ class StreamElementsTipEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.avatar(
       avatar: const AssetImage("assets/streamelements.png"),
       child: Column(
@@ -17,8 +19,7 @@ class StreamElementsTipEventWidget extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             StyledText(
-              text:
-                  '<b>${model.name}</b> tipped <b>${model.formattedAmount}</b> on StreamElements.',
+              text: loc.streamElementsTipEventMessage(model.name, model.formattedAmount),
               tags: {
                 'b': StyledTextTag(
                     style: Theme.of(context).textTheme.titleSmall),

--- a/lib/components/chat_history/auxiliary/streamelements.dart
+++ b/lib/components/chat_history/auxiliary/streamelements.dart
@@ -11,7 +11,6 @@ class StreamElementsTipEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.avatar(
       avatar: const AssetImage("assets/streamelements.png"),
       child: Column(
@@ -19,7 +18,8 @@ class StreamElementsTipEventWidget extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             StyledText(
-              text: loc.streamElementsTipEventMessage(model.name, model.formattedAmount),
+              text: AppLocalizations.of(context)!.streamElementsTipEventMessage(
+                  model.name, model.formattedAmount),
               tags: {
                 'b': StyledTextTag(
                     style: Theme.of(context).textTheme.titleSmall),

--- a/lib/components/chat_history/auxiliary/streamlabs.dart
+++ b/lib/components/chat_history/auxiliary/streamlabs.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/models/messages/auxiliary/streamlabs.dart';
 import 'package:styled_text/styled_text.dart';
@@ -10,6 +11,7 @@ class StreamlabsDonationEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.avatar(
       avatar: const AssetImage("assets/streamlabs.png"),
       child: Column(
@@ -17,8 +19,7 @@ class StreamlabsDonationEventWidget extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             StyledText(
-              text:
-                  '<b>${model.name}</b> tipped <b>${model.formattedAmount}</b> on Streamlabs.',
+              text: loc.streamlabsDonationEventMessage(model.name, model.formattedAmount),
               tags: {
                 'b': StyledTextTag(
                     style: Theme.of(context).textTheme.titleSmall),

--- a/lib/components/chat_history/auxiliary/streamlabs.dart
+++ b/lib/components/chat_history/auxiliary/streamlabs.dart
@@ -11,7 +11,6 @@ class StreamlabsDonationEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.avatar(
       avatar: const AssetImage("assets/streamlabs.png"),
       child: Column(
@@ -19,7 +18,9 @@ class StreamlabsDonationEventWidget extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             StyledText(
-              text: loc.streamlabsDonationEventMessage(model.name, model.formattedAmount),
+              text: AppLocalizations.of(context)!
+                  .streamlabsDonationEventMessage(
+                      model.name, model.formattedAmount),
               tags: {
                 'b': StyledTextTag(
                     style: Theme.of(context).textTheme.titleSmall),

--- a/lib/components/chat_history/twitch/channel_point_event.dart
+++ b/lib/components/chat_history/twitch/channel_point_event.dart
@@ -18,11 +18,11 @@ class TwitchChannelPointRedemptionEventWidget extends StatelessWidget {
             ? AppLocalizations.of(context)!.channelPointRedemptionWithUserInput(
                 model.redeemerUsername,
                 model.rewardName,
-                model.rewardCost.toString(),
+                model.rewardCost,
                 model.userInput!)
             : AppLocalizations.of(context)!
-                .channelPointRedemptionWithoutUserInput(model.redeemerUsername,
-                    model.rewardName, model.rewardCost.toString()),
+                .channelPointRedemptionWithoutUserInput(
+                    model.redeemerUsername, model.rewardName, model.rewardCost),
         tags: {
           'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
         },

--- a/lib/components/chat_history/twitch/channel_point_event.dart
+++ b/lib/components/chat_history/twitch/channel_point_event.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/models/messages/twitch/channel_point_redemption_event.dart';
 import 'package:styled_text/styled_text.dart';
@@ -10,11 +11,13 @@ class TwitchChannelPointRedemptionEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.icon(
       icon: model.icon,
       child: StyledText(
-        text:
-            '<b>${model.redeemerUsername}</b> redeemed <b>${model.rewardName}</b> for ${model.rewardCost} points. ${model.userInput ?? ''}',
+        text: model.userInput != null
+            ? loc.channelPointRedemptionWithUserInput(model.redeemerUsername, model.rewardName, model.rewardCost.toString(), model.userInput!)
+            : loc.channelPointRedemptionWithoutUserInput(model.redeemerUsername, model.rewardName, model.rewardCost.toString()),
         tags: {
           'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
         },

--- a/lib/components/chat_history/twitch/channel_point_event.dart
+++ b/lib/components/chat_history/twitch/channel_point_event.dart
@@ -11,13 +11,18 @@ class TwitchChannelPointRedemptionEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.icon(
       icon: model.icon,
       child: StyledText(
         text: model.userInput != null
-            ? loc.channelPointRedemptionWithUserInput(model.redeemerUsername, model.rewardName, model.rewardCost.toString(), model.userInput!)
-            : loc.channelPointRedemptionWithoutUserInput(model.redeemerUsername, model.rewardName, model.rewardCost.toString()),
+            ? AppLocalizations.of(context)!.channelPointRedemptionWithUserInput(
+                model.redeemerUsername,
+                model.rewardName,
+                model.rewardCost.toString(),
+                model.userInput!)
+            : AppLocalizations.of(context)!
+                .channelPointRedemptionWithoutUserInput(model.redeemerUsername,
+                    model.rewardName, model.rewardCost.toString()),
         tags: {
           'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
         },

--- a/lib/components/chat_history/twitch/cheer_event.dart
+++ b/lib/components/chat_history/twitch/cheer_event.dart
@@ -19,12 +19,14 @@ class TwitchCheerEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
-    final name = model.isAnonymous ? loc.anonymous : model.giverName;
+    final name = model.isAnonymous
+        ? AppLocalizations.of(context)!.anonymous
+        : model.giverName ?? AppLocalizations.of(context)!.anonymous;
     return DecoratedEventWidget.avatar(
       avatar: ResilientNetworkImage(getCorrespondingImageUrl(model.bits)),
       child: StyledText(
-        text: loc.cheerEventMessage(name, model.bits, model.cheerMessage),
+        text: AppLocalizations.of(context)!
+            .cheerEventMessage(name, model.bits, model.cheerMessage),
         tags: {
           'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
         },

--- a/lib/components/chat_history/twitch/cheer_event.dart
+++ b/lib/components/chat_history/twitch/cheer_event.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/components/image/resilient_network_image.dart';
 import 'package:rtchat/models/messages/twitch/event.dart';
@@ -18,11 +19,12 @@ class TwitchCheerEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final name = model.isAnonymous ? 'Anonymous' : model.giverName;
+    final loc = AppLocalizations.of(context)!;
+    final name = model.isAnonymous ? loc.anonymous : model.giverName;
     return DecoratedEventWidget.avatar(
       avatar: ResilientNetworkImage(getCorrespondingImageUrl(model.bits)),
       child: StyledText(
-        text: '<b>$name</b> cheered <b>${model.bits}</b> bits. ${model.cheerMessage}',
+        text: loc.cheerEventMessage(name, model.bits, model.cheerMessage),
         tags: {
           'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
         },

--- a/lib/components/chat_history/twitch/host_event.dart
+++ b/lib/components/chat_history/twitch/host_event.dart
@@ -12,11 +12,12 @@ class TwitchHostEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.avatar(
       avatar: ResilientNetworkImage(model.from.profilePictureUrl),
       child: StyledText(
-        text: loc.hostEventMessage(model.from.displayName, model.viewers.toString()),
+        text: AppLocalizations.of(context)!.hostEventMessage(
+            model.from.displayName ?? AppLocalizations.of(context)!.anonymous,
+            model.viewers),
         tags: {
           'b': StyledTextTag(
               style: Theme.of(context)

--- a/lib/components/chat_history/twitch/host_event.dart
+++ b/lib/components/chat_history/twitch/host_event.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/components/image/resilient_network_image.dart';
 import 'package:rtchat/models/messages/twitch/event.dart';
@@ -11,11 +12,11 @@ class TwitchHostEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.avatar(
       avatar: ResilientNetworkImage(model.from.profilePictureUrl),
       child: StyledText(
-        text:
-            '<b>${model.from.displayName}</b> is hosting with a party of <b>${model.viewers}</b>',
+        text: loc.hostEventMessage(model.from.displayName, model.viewers.toString()),
         tags: {
           'b': StyledTextTag(
               style: Theme.of(context)

--- a/lib/components/chat_history/twitch/hype_train_event.dart
+++ b/lib/components/chat_history/twitch/hype_train_event.dart
@@ -11,20 +11,25 @@ class TwitchHypeTrainEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.icon(
       icon: Icons.train,
       child: Builder(builder: (context) {
         if (model.hasEnded) {
           return StyledText(
-            text: loc.hypeTrainEventEnded(model.level.toString(), model.isSuccessful ? loc.successful : loc.notSuccessful),
+            text: model.isSuccessful
+                ? AppLocalizations.of(context)!
+                    .hypeTrainEventEndedSuccessful(model.level)
+                : AppLocalizations.of(context)!
+                    .hypeTrainEventEndedUnsuccessful(model.level),
             tags: {
               'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
             },
           );
         } else {
           return StyledText(
-            text: loc.hypeTrainEventProgress(model.level.toString(), ((model.progress * 100) ~/ model.goal).toString()),
+            text: AppLocalizations.of(context)!.hypeTrainEventProgress(
+                model.level.toString(),
+                ((model.progress * 100) ~/ model.goal).toString()),
             tags: {
               'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
             },

--- a/lib/components/chat_history/twitch/hype_train_event.dart
+++ b/lib/components/chat_history/twitch/hype_train_event.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:rtchat/components/chat_history/decorated_event.dart';
 import 'package:rtchat/models/messages/twitch/hype_train_event.dart';
 import 'package:styled_text/styled_text.dart';
@@ -10,21 +11,20 @@ class TwitchHypeTrainEventWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return DecoratedEventWidget.icon(
       icon: Icons.train,
       child: Builder(builder: (context) {
         if (model.hasEnded) {
           return StyledText(
-            text:
-                'Hype Train level <b>${model.level}</b> ${model.isSuccessful ? 'succeeded! ' : 'was not successful. '}',
+            text: loc.hypeTrainEventEnded(model.level.toString(), model.isSuccessful ? loc.successful : loc.notSuccessful),
             tags: {
               'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
             },
           );
         } else {
           return StyledText(
-            text: 'Hype Train level <b>${model.level}</b> in progress! '
-                '${(model.progress * 100) ~/ model.goal}% completed!',
+            text: loc.hypeTrainEventProgress(model.level.toString(), ((model.progress * 100) ~/ model.goal).toString()),
             tags: {
               'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
             },

--- a/lib/components/chat_history/twitch/raiding_event.dart
+++ b/lib/components/chat_history/twitch/raiding_event.dart
@@ -38,7 +38,8 @@ class TwitchRaidingEventWidget extends StatelessWidget {
                     Expanded(
                       child: StyledText(
                         text: AppLocalizations.of(context)!.raidingEventRaiding(
-                            model.targetUser.displayName ?? ''),
+                            model.targetUser.displayName ??
+                                AppLocalizations.of(context)!.anonymous),
                         tags: {
                           'b': StyledTextTag(
                               style: Theme.of(context).textTheme.titleSmall),
@@ -63,8 +64,9 @@ class TwitchRaidingEventWidget extends StatelessWidget {
               child: Row(children: [
                 Expanded(
                   child: StyledText(
-                    text: AppLocalizations.of(context)!
-                        .raidingEventRaided(model.targetUser.displayName ?? ''),
+                    text: AppLocalizations.of(context)!.raidingEventRaided(
+                        model.targetUser.displayName ??
+                            AppLocalizations.of(context)!.anonymous),
                     tags: {
                       'b': StyledTextTag(
                           style: Theme.of(context).textTheme.titleSmall),
@@ -87,8 +89,9 @@ class TwitchRaidingEventWidget extends StatelessWidget {
       return DecoratedEventWidget.avatar(
           avatar: ResilientNetworkImage(model.targetUser.profilePictureUrl),
           child: StyledText(
-            text: AppLocalizations.of(context)!
-                .raidingEventCanceled(model.targetUser.displayName ?? ''),
+            text: AppLocalizations.of(context)!.raidingEventCanceled(
+                model.targetUser.displayName ??
+                    AppLocalizations.of(context)!.anonymous),
             tags: {
               'b': StyledTextTag(style: Theme.of(context).textTheme.titleSmall),
             },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -897,6 +897,10 @@
       }
     }
   },
+  "anonymous": "Anonymous",
+  "@anonymous": {
+    "description": "Username of an anonymous user"
+  },
   "hostEventMessage": "<b>{fromDisplayName}</b> is hosting you with <b>{viewers}</b> viewers!",
   "@hostEventMessage": {
     "description": "Message displayed when a host event occurs",
@@ -925,17 +929,25 @@
       }
     }
   },
-  "hypeTrainEventEnded": "Hype Train ended at level <b>{level}</b> and was <b>{result}</b>",
-  "@hypeTrainEventEnded": {
-    "description": "Message displayed when a hype train event ends",
+  "hypeTrainEventEndedSuccessful": "Hype Train ended at level <b>{level}</b> and was <b>successful</b>",
+  "@hypeTrainEventEndedSuccessful": {
+    "description": "Message displayed when a hype train event ends successfully",
     "placeholders": {
       "level": {
-        "type": "String",
+        "type": "int",
+        "format": "decimalPattern",
         "example": "3"
-      },
-      "result": {
-        "type": "String",
-        "example": "successful"
+      }
+    }
+  },
+  "hypeTrainEventEndedUnsuccessful": "Hype Train ended at level <b>{level}</b> and was <b>not successful</b>",
+  "@hypeTrainEventEndedUnsuccessful": {
+    "description": "Message displayed when a hype train event ends unsuccessfully",
+    "placeholders": {
+      "level": {
+        "type": "int",
+        "format": "decimalPattern",
+        "example": "3"
       }
     }
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -778,5 +778,165 @@
         "example": "1"
       }
     }
+  },
+  "realtimeCashDonationWithDonor": "<b>{donor}</b> donated <b>{value} {currency}</b>",
+  "@realtimeCashDonationWithDonor": {
+    "description": "Message displayed when a RealtimeCash donation is made with a donor name",
+    "placeholders": {
+      "donor": {
+        "type": "String",
+        "example": "JohnDoe"
+      },
+      "value": {
+        "type": "String",
+        "example": "5"
+      },
+      "currency": {
+        "type": "String",
+        "example": "USD"
+      }
+    }
+  },
+  "realtimeCashDonationAnonymous": "An anonymous user donated <b>{value} {currency}</b>",
+  "@realtimeCashDonationAnonymous": {
+    "description": "Message displayed when a RealtimeCash donation is made anonymously",
+    "placeholders": {
+      "value": {
+        "type": "String",
+        "example": "5"
+      },
+      "currency": {
+        "type": "String",
+        "example": "USD"
+      }
+    }
+  },
+  "streamElementsTipEventMessage": "<b>{name}</b> tipped <b>{formattedAmount}</b>",
+  "@streamElementsTipEventMessage": {
+    "description": "Message displayed when a StreamElements tip event occurs",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "JohnDoe"
+      },
+      "formattedAmount": {
+        "type": "String",
+        "example": "$5.00"
+      }
+    }
+  },
+  "streamlabsDonationEventMessage": "<b>{name}</b> donated <b>{formattedAmount}</b>",
+  "@streamlabsDonationEventMessage": {
+    "description": "Message displayed when a Streamlabs donation event occurs",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "JohnDoe"
+      },
+      "formattedAmount": {
+        "type": "String",
+        "example": "$5.00"
+      }
+    }
+  },
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> redeemed <b>{rewardName}</b> for <b>{rewardCost}</b> points with message: <b>{userInput}</b>",
+  "@channelPointRedemptionWithUserInput": {
+    "description": "Message displayed when a channel point redemption event occurs with user input",
+    "placeholders": {
+      "redeemerUsername": {
+        "type": "String",
+        "example": "JohnDoe"
+      },
+      "rewardName": {
+        "type": "String",
+        "example": "Highlight My Message"
+      },
+      "rewardCost": {
+        "type": "String",
+        "example": "100"
+      },
+      "userInput": {
+        "type": "String",
+        "example": "Hello World!"
+      }
+    }
+  },
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> redeemed <b>{rewardName}</b> for <b>{rewardCost}</b> points",
+  "@channelPointRedemptionWithoutUserInput": {
+    "description": "Message displayed when a channel point redemption event occurs without user input",
+    "placeholders": {
+      "redeemerUsername": {
+        "type": "String",
+        "example": "JohnDoe"
+      },
+      "rewardName": {
+        "type": "String",
+        "example": "Highlight My Message"
+      },
+      "rewardCost": {
+        "type": "String",
+        "example": "100"
+      }
+    }
+  },
+  "cheerEventMessage": "<b>{name}</b> cheered <b>{bits}</b> bits with message: <b>{cheerMessage}</b>",
+  "@cheerEventMessage": {
+    "description": "Message displayed when a cheer event occurs",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "JohnDoe"
+      },
+      "bits": {
+        "type": "int",
+        "format": "decimalPattern"
+      },
+      "cheerMessage": {
+        "type": "String",
+        "example": "Great stream!"
+      }
+    }
+  },
+  "hostEventMessage": "<b>{fromDisplayName}</b> is hosting you with <b>{viewers}</b> viewers!",
+  "@hostEventMessage": {
+    "description": "Message displayed when a host event occurs",
+    "placeholders": {
+      "fromDisplayName": {
+        "type": "String",
+        "example": "JohnDoe"
+      },
+      "viewers": {
+        "type": "int",
+        "format": "decimalPattern"
+      }
+    }
+  },
+  "hypeTrainEventProgress": "Hype Train is at level <b>{level}</b> with <b>{progressPercent}%</b> progress",
+  "@hypeTrainEventProgress": {
+    "description": "Message displayed when a hype train event is in progress",
+    "placeholders": {
+      "level": {
+        "type": "String",
+        "example": "3"
+      },
+      "progressPercent": {
+        "type": "String",
+        "example": "75"
+      }
+    }
+  },
+  "hypeTrainEventEnded": "Hype Train ended at level <b>{level}</b> and was <b>{result}</b>",
+  "@hypeTrainEventEnded": {
+    "description": "Message displayed when a hype train event ends",
+    "placeholders": {
+      "level": {
+        "type": "String",
+        "example": "3"
+      },
+      "result": {
+        "type": "String",
+        "example": "successful"
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -903,7 +903,7 @@
   "@anonymous": {
     "description": "Username of an anonymous user"
   },
-  "hostEventMessage": "<b>{fromDisplayName}</b> is hosting you with <b>{viewers}</b> viewers!",
+  "hostEventMessage": "<b>{fromDisplayName}</b> is hosting with a party of <b>{viewers}</b>.",
   "@hostEventMessage": {
     "description": "Message displayed when a host event occurs",
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -797,7 +797,7 @@
       }
     }
   },
-  "realtimeCashDonationAnonymous": "An anonymous user donated <b>{value} {currency}</b>.",
+  "realtimeCashDonationAnonymous": "Anonymous donated <b>{value} {currency}</b>.",
   "@realtimeCashDonationAnonymous": {
     "description": "Message displayed when a RealtimeCash donation is made anonymously",
     "placeholders": {
@@ -811,7 +811,7 @@
       }
     }
   },
-  "streamElementsTipEventMessage": "<b>{name}</b> tipped <b>{formattedAmount}</b>.",
+  "streamElementsTipEventMessage": "<b>{name}</b> tipped <b>{formattedAmount}</b> on StreamElements.",
   "@streamElementsTipEventMessage": {
     "description": "Message displayed when a StreamElements tip event occurs",
     "placeholders": {
@@ -825,7 +825,7 @@
       }
     }
   },
-  "streamlabsDonationEventMessage": "<b>{name}</b> donated <b>{formattedAmount}</b>.",
+  "streamlabsDonationEventMessage": "<b>{name}</b> tipped <b>{formattedAmount}</b> on Streamlabs.",
   "@streamlabsDonationEventMessage": {
     "description": "Message displayed when a Streamlabs donation event occurs",
     "placeholders": {
@@ -839,7 +839,7 @@
       }
     }
   },
-  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> redeemed <b>{rewardName}</b> for <b>{rewardCost}</b> points. <b>{userInput}</b>",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> redeemed <b>{rewardName}</b> for <b>{rewardCost}</b> points. {userInput}",
   "@channelPointRedemptionWithUserInput": {
     "description": "Message displayed when a channel point redemption event occurs with user input",
     "placeholders": {
@@ -881,7 +881,7 @@
       }
     }
   },
-  "cheerEventMessage": "<b>{name}</b> cheered <b>{bits}</b> bits. <b>{cheerMessage}</b>",
+  "cheerEventMessage": "<b>{name}</b> cheered <b>{bits}</b> bits. {cheerMessage}",
   "@cheerEventMessage": {
     "description": "Message displayed when a cheer event occurs",
     "placeholders": {
@@ -917,7 +917,7 @@
       }
     }
   },
-  "hypeTrainEventProgress": "Hype Train is at level <b>{level}</b> with <b>{progressPercent}%</b> progress.",
+  "hypeTrainEventProgress": "Hype Train level <b>{level}</b> in progress! <b>{progressPercent}%</b> completed!",
   "@hypeTrainEventProgress": {
     "description": "Message displayed when a hype train event is in progress",
     "placeholders": {
@@ -931,7 +931,7 @@
       }
     }
   },
-  "hypeTrainEventEndedSuccessful": "Hype Train ended at level <b>{level}</b> and was <b>successful</b>.",
+  "hypeTrainEventEndedSuccessful": "Hype Train level <b>{level}</b> succeeded.",
   "@hypeTrainEventEndedSuccessful": {
     "description": "Message displayed when a hype train event ends successfully",
     "placeholders": {
@@ -942,7 +942,7 @@
       }
     }
   },
-  "hypeTrainEventEndedUnsuccessful": "Hype Train ended at level <b>{level}</b> and was <b>not successful</b>.",
+  "hypeTrainEventEndedUnsuccessful": "Hype Train level <b>{level}</b> failed.",
   "@hypeTrainEventEndedUnsuccessful": {
     "description": "Message displayed when a hype train event ends unsuccessfully",
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -623,11 +623,11 @@
   "@customizeYourHostEvent": {
     "description": "Subtitle for the host event configuration"
   },
-  "hypetrainEventConfigTitle": "Hypetrain Event",
+  "hypetrainEventConfigTitle": "Hype Train Event",
   "@hypetrainEventConfigTitle": {
     "description": "Title for the hypetrain event configuration"
   },
-  "customizeYourHypetrainEvent": "Customize your hypetrain event",
+  "customizeYourHypetrainEvent": "Customize your hype train event",
   "@customizeYourHypetrainEvent": {
     "description": "Subtitle for the hypetrain event configuration"
   },
@@ -681,7 +681,7 @@
   "@shoutout": {
     "description": "Button text for the shoutout action in a raid event"
   },
-  "raidingEventRaiding": "<b>{displayName}</b> is raiding...",
+  "raidingEventRaiding": "Raiding <b>{displayName}</b>...",
   "@raidingEventRaiding": {
     "description": "Message displayed when a raiding event is in progress",
     "placeholders": {
@@ -691,7 +691,7 @@
       }
     }
   },
-  "raidingEventTimeRemaining": "Time remaining: {seconds}s",
+  "raidingEventTimeRemaining": "{seconds}s",
   "@raidingEventTimeRemaining": {
     "description": "Message displaying the time remaining for a raiding event",
     "placeholders": {
@@ -779,7 +779,7 @@
       }
     }
   },
-  "realtimeCashDonationWithDonor": "<b>{donor}</b> donated <b>{value} {currency}</b>",
+  "realtimeCashDonationWithDonor": "<b>{donor}</b> donated <b>{value} {currency}</b>.",
   "@realtimeCashDonationWithDonor": {
     "description": "Message displayed when a RealtimeCash donation is made with a donor name",
     "placeholders": {
@@ -797,7 +797,7 @@
       }
     }
   },
-  "realtimeCashDonationAnonymous": "An anonymous user donated <b>{value} {currency}</b>",
+  "realtimeCashDonationAnonymous": "An anonymous user donated <b>{value} {currency}</b>.",
   "@realtimeCashDonationAnonymous": {
     "description": "Message displayed when a RealtimeCash donation is made anonymously",
     "placeholders": {
@@ -811,7 +811,7 @@
       }
     }
   },
-  "streamElementsTipEventMessage": "<b>{name}</b> tipped <b>{formattedAmount}</b>",
+  "streamElementsTipEventMessage": "<b>{name}</b> tipped <b>{formattedAmount}</b>.",
   "@streamElementsTipEventMessage": {
     "description": "Message displayed when a StreamElements tip event occurs",
     "placeholders": {
@@ -825,7 +825,7 @@
       }
     }
   },
-  "streamlabsDonationEventMessage": "<b>{name}</b> donated <b>{formattedAmount}</b>",
+  "streamlabsDonationEventMessage": "<b>{name}</b> donated <b>{formattedAmount}</b>.",
   "@streamlabsDonationEventMessage": {
     "description": "Message displayed when a Streamlabs donation event occurs",
     "placeholders": {
@@ -839,7 +839,7 @@
       }
     }
   },
-  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> redeemed <b>{rewardName}</b> for <b>{rewardCost}</b> points with message: <b>{userInput}</b>",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> redeemed <b>{rewardName}</b> for <b>{rewardCost}</b> points. <b>{userInput}</b>",
   "@channelPointRedemptionWithUserInput": {
     "description": "Message displayed when a channel point redemption event occurs with user input",
     "placeholders": {
@@ -852,7 +852,8 @@
         "example": "Highlight My Message"
       },
       "rewardCost": {
-        "type": "String",
+        "type": "int",
+        "format": "decimalPattern",
         "example": "100"
       },
       "userInput": {
@@ -861,7 +862,7 @@
       }
     }
   },
-  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> redeemed <b>{rewardName}</b> for <b>{rewardCost}</b> points",
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> redeemed <b>{rewardName}</b> for <b>{rewardCost}</b> points.",
   "@channelPointRedemptionWithoutUserInput": {
     "description": "Message displayed when a channel point redemption event occurs without user input",
     "placeholders": {
@@ -874,12 +875,13 @@
         "example": "Highlight My Message"
       },
       "rewardCost": {
-        "type": "String",
+        "type": "int",
+        "format": "decimalPattern",
         "example": "100"
       }
     }
   },
-  "cheerEventMessage": "<b>{name}</b> cheered <b>{bits}</b> bits with message: <b>{cheerMessage}</b>",
+  "cheerEventMessage": "<b>{name}</b> cheered <b>{bits}</b> bits. <b>{cheerMessage}</b>",
   "@cheerEventMessage": {
     "description": "Message displayed when a cheer event occurs",
     "placeholders": {
@@ -915,7 +917,7 @@
       }
     }
   },
-  "hypeTrainEventProgress": "Hype Train is at level <b>{level}</b> with <b>{progressPercent}%</b> progress",
+  "hypeTrainEventProgress": "Hype Train is at level <b>{level}</b> with <b>{progressPercent}%</b> progress.",
   "@hypeTrainEventProgress": {
     "description": "Message displayed when a hype train event is in progress",
     "placeholders": {
@@ -929,7 +931,7 @@
       }
     }
   },
-  "hypeTrainEventEndedSuccessful": "Hype Train ended at level <b>{level}</b> and was <b>successful</b>",
+  "hypeTrainEventEndedSuccessful": "Hype Train ended at level <b>{level}</b> and was <b>successful</b>.",
   "@hypeTrainEventEndedSuccessful": {
     "description": "Message displayed when a hype train event ends successfully",
     "placeholders": {
@@ -940,7 +942,7 @@
       }
     }
   },
-  "hypeTrainEventEndedUnsuccessful": "Hype Train ended at level <b>{level}</b> and was <b>not successful</b>",
+  "hypeTrainEventEndedUnsuccessful": "Hype Train ended at level <b>{level}</b> and was <b>not successful</b>.",
   "@hypeTrainEventEndedUnsuccessful": {
     "description": "Message displayed when a hype train event ends unsuccessfully",
     "placeholders": {

--- a/test/components/chat_history/twitch/channel_point_event_test.dart
+++ b/test/components/chat_history/twitch/channel_point_event_test.dart
@@ -6,6 +6,8 @@ import 'package:rtchat/models/messages/twitch/channel_point_redemption_event.dar
 import 'package:rtchat/models/style.dart';
 import 'package:styled_text/styled_text.dart';
 
+import '../../l10n.dart';
+
 void main() {
   testWidgets(
       'fulfilled channel point redemption should have done icon and message',
@@ -20,10 +22,12 @@ void main() {
         userInput: null);
     await tester.pumpWidget(buildWidget(model));
 
+    await tester.pumpAndSettle();
+
     final findText = find.byWidgetPredicate((Widget widget) {
-      return widget is StyledText &&
-          widget.text ==
-              '<b>automux</b> redeemed <b>Sprint</b> for 100 points. ';
+      return widget is RichText &&
+          widget.text.toPlainText() ==
+              'automux redeemed Sprint for 100 points.';
     });
 
     final findIcon = find.byIcon(Icons.done);
@@ -45,10 +49,12 @@ void main() {
         userInput: "user input Kappa");
     await tester.pumpWidget(buildWidget(model));
 
+    await tester.pumpAndSettle();
+
     final findText = find.byWidgetPredicate((Widget widget) {
-      return widget is StyledText &&
-          widget.text ==
-              '<b>automux</b> redeemed <b>WaTeER</b> for 350 points. user input Kappa';
+      return widget is RichText &&
+          widget.text.toPlainText() ==
+              'automux redeemed WaTeER for 350 points. user input Kappa';
     });
 
     final findIcon = find.byIcon(Icons.timer);
@@ -58,9 +64,9 @@ void main() {
   });
 }
 
-ChangeNotifierProvider<StyleModel> buildWidget(
-    TwitchChannelPointRedemptionEventModel model) {
-  return ChangeNotifierProvider<StyleModel>.value(
+Widget buildWidget(TwitchChannelPointRedemptionEventModel model) {
+  return TestLocalizations(
+      child: ChangeNotifierProvider<StyleModel>.value(
     value: StyleModel.fromJson({
       "fontSize": 20.0,
       "lightnessBoost": 0.179,
@@ -71,5 +77,5 @@ ChangeNotifierProvider<StyleModel> buildWidget(
         child: MediaQuery(
             data: const MediaQueryData(),
             child: TwitchChannelPointRedemptionEventWidget(model))),
-  );
+  ));
 }

--- a/test/components/chat_history/twitch/channel_point_event_test.dart
+++ b/test/components/chat_history/twitch/channel_point_event_test.dart
@@ -4,7 +4,6 @@ import 'package:provider/provider.dart';
 import 'package:rtchat/components/chat_history/twitch/channel_point_event.dart';
 import 'package:rtchat/models/messages/twitch/channel_point_redemption_event.dart';
 import 'package:rtchat/models/style.dart';
-import 'package:styled_text/styled_text.dart';
 
 import '../../l10n.dart';
 

--- a/test/components/chat_history/twitch/host_event_test.dart
+++ b/test/components/chat_history/twitch/host_event_test.dart
@@ -7,7 +7,6 @@ import 'package:rtchat/components/chat_history/twitch/host_event.dart';
 import 'package:rtchat/models/messages/twitch/event.dart';
 import 'package:rtchat/models/messages/twitch/user.dart';
 import 'package:rtchat/models/style.dart';
-import 'package:styled_text/styled_text.dart';
 
 import '../../l10n.dart';
 

--- a/test/components/chat_history/twitch/host_event_test.dart
+++ b/test/components/chat_history/twitch/host_event_test.dart
@@ -9,6 +9,8 @@ import 'package:rtchat/models/messages/twitch/user.dart';
 import 'package:rtchat/models/style.dart';
 import 'package:styled_text/styled_text.dart';
 
+import '../../l10n.dart';
+
 void main() {
   AutomatedTestWidgetsFlutterBinding();
   HttpOverrides.global = null;
@@ -23,24 +25,28 @@ void main() {
     );
     await tester.pumpWidget(buildWidget(model));
 
+    await tester.pumpAndSettle();
+
     final findText = find.byWidgetPredicate((Widget widget) =>
-        widget is StyledText &&
-        widget.text == "<b>automux</b> is hosting with a party of <b>10</b>");
+        widget is RichText &&
+        widget.text.toPlainText() == "automux is hosting with a party of 10");
 
     expect(findText, findsOneWidget);
   });
 }
 
-ChangeNotifierProvider<StyleModel> buildWidget(TwitchHostEventModel model) {
-  return ChangeNotifierProvider<StyleModel>.value(
-    value: StyleModel.fromJson({
-      "fontSize": 20.0,
-      "lightnessBoost": 0.179,
-      "isDeletedMessagesVisible": true
-    }),
-    child: Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-            data: const MediaQueryData(), child: TwitchHostEventWidget(model))),
+Widget buildWidget(TwitchHostEventModel model) {
+  return TestLocalizations(
+    child: ChangeNotifierProvider<StyleModel>.value(
+        value: StyleModel.fromJson({
+          "fontSize": 20.0,
+          "lightnessBoost": 0.179,
+          "isDeletedMessagesVisible": true
+        }),
+        child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: MediaQuery(
+                data: const MediaQueryData(),
+                child: TwitchHostEventWidget(model)))),
   );
 }

--- a/test/components/chat_history/twitch/host_event_test.dart
+++ b/test/components/chat_history/twitch/host_event_test.dart
@@ -28,7 +28,7 @@ void main() {
 
     final findText = find.byWidgetPredicate((Widget widget) =>
         widget is RichText &&
-        widget.text.toPlainText() == "automux is hosting with a party of 10");
+        widget.text.toPlainText() == "automux is hosting with a party of 10.");
 
     expect(findText, findsOneWidget);
   });

--- a/test/components/l10n.dart
+++ b/test/components/l10n.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localized_locales/flutter_localized_locales.dart';
+
+class TestLocalizations extends StatelessWidget {
+  final Widget child;
+  const TestLocalizations({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Localizations(
+      delegates: const [
+        ...AppLocalizations.localizationsDelegates,
+        LocaleNamesLocalizationsDelegate(),
+      ],
+      locale: const Locale('en'),
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
Localizes static strings in various components of the chat history, including those with style tags, and updates localization files.

- Localizes static strings in `RealtimeCashDonationEventWidget`, `StreamElementsTipEventWidget`, `StreamlabsDonationEventWidget`, `TwitchChannelPointRedemptionEventWidget`, `TwitchCheerEventWidget`, `TwitchHostEventWidget`, and `TwitchHypeTrainEventWidget`. This includes handling both cases where the donor is known and anonymous, as well as including style tags within the localized strings as needed.
- Updates the `app_en.arb` localization file with new entries for the localized strings extracted from the above components. This ensures that all static strings, including those with style tags, are now localized according to the task requirements.
- Ensures that the localization includes dynamic content such as usernames, donation amounts, and currency, making the chat history components adaptable to different languages and regions.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat?shareId=1f2bd580-1a27-4a4f-a485-7263c9cb1822).