### PR TITLE
fix: emote picker migration

### DIFF
--- a/lib/components/emote_picker.dart
+++ b/lib/components/emote_picker.dart
@@ -32,53 +32,73 @@ class EmotesList extends StatelessWidget {
     });
     final categories = byCategory.keys.toList();
     categories.sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+
     // ensure global emotes is first.
     final globalEmotesIndex = categories.indexOf(globalEmotes);
     if (globalEmotesIndex != -1) {
       categories.removeAt(globalEmotesIndex);
       categories.insert(0, globalEmotes);
     }
+
     // ensure channel emotes is second.
     final channelEmotesIndex = categories.indexOf(channel.displayName);
     if (channelEmotesIndex != -1) {
       categories.removeAt(channelEmotesIndex);
       categories.insert(1, channel.displayName);
     }
+
     return ListView.builder(
-        itemCount: byCategory.length,
-        itemBuilder: (context, index) {
-          return StickyHeader(
-            header: Container(
-              color: Theme.of(context).inputDecorationTheme.fillColor,
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              alignment: Alignment.centerLeft,
-              child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Text(
-                    categories[index],
-                    style:
-                        TextStyle(color: Theme.of(context).colorScheme.primary),
-                  )),
+      itemCount: categories.length,
+      itemBuilder: (context, index) {
+        return StickyHeader(
+          overlapHeaders: false,
+          header: Container(
+            width: MediaQuery.of(context).size.width,
+            color: Theme.of(context).scaffoldBackgroundColor,
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            alignment: Alignment.centerLeft,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 16.0, bottom: 8.0),
+              child: Text(
+                categories[index],
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.primary,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16.0,
+                ),
+              ),
             ),
-            content: Center(
-                child: Wrap(
-              children: byCategory[categories[index]]!.map((emote) {
-                return Tooltip(
+          ),
+          content: Padding(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+            child: Center(
+              child: Wrap(
+                alignment: WrapAlignment.start,
+                spacing: 8.0,
+                runSpacing: 8.0,
+                children: byCategory[categories[index]]!.map((emote) {
+                  return Tooltip(
                     message: emote.code,
                     preferBelow: false,
                     child: IconButton(
-                        onPressed: () => onEmoteSelected(emote),
-                        splashRadius: 24,
-                        icon: CrossFadeImage(
-                          placeholder: emote.image.placeholderImage,
-                          image: emote.image,
-                          width: 36,
-                          height: 36,
-                        )));
-              }).toList(),
-            )),
-          );
-        });
+                      onPressed: () => onEmoteSelected(emote),
+                      splashRadius: 24,
+                      icon: CrossFadeImage(
+                        placeholder: emote.image.placeholderImage,
+                        image: emote.image,
+                        width: 36,
+                        height: 36,
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+        );
+      },
+    );
   }
 }
 


### PR DESCRIPTION
When migrating from material 2 to material 3 it changed the way the emote picker worked, this led to emotes being present behind the channel text and not matching the native app. I added the bar again and kept most material 3 improvements.