### PR TITLE
feat: add translations for new keys

### DIFF
--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -112,5 +112,19 @@
   "durationOneDayTimeoutPrompt": "1 দিনের জন্য সময়সীমা",
   "durationTwoDaysTimeoutPrompt": "2 দিনের জন্য সময়সীমা",
   "durationOneWeekTimeoutPrompt": "1 সপ্তাহের জন্য সময়সীমা",
-  "durationTwoWeeksTimeoutPrompt": "2 সপ্তাহের জন্য সময়সীমা"
+  "durationTwoWeeksTimeoutPrompt": "2 সপ্তাহের জন্য সময়সীমা",
+  "errorFetchingViewerList": "এই চ্যানেলের জন্য দর্শকের তালিকা আনা যায়নি",
+  "eventsTitle": "ইভেন্টস",
+  "followEventConfigTitle": "অনুসরণ ইভেন্ট",
+  "customizeYourFollowEvent": "আপনার অনুসরণ ইভেন্ট কাস্টমাইজ করুন",
+  "subscribeEventConfigTitle": "সাবস্ক্রাইব ইভেন্ট",
+  "customizeYourSubscriptionEvent": "আপনার সাবস্ক্রিপশন ইভেন্ট কাস্টমাইজ করুন",
+  "cheerEventConfigTitle": "চিয়ার ইভেন্ট",
+  "customizeYourCheerEvent": "আপনার চিয়ার ইভেন্ট কাস্টমাইজ করুন",
+  "raidEventConfigTitle": "রেইড ইভেন্ট",
+  "customizeYourRaidEvent": "আপনার রেইড ইভেন্ট কাস্টমাইজ করুন",
+  "hostEventConfigTitle": "হোস্ট ইভেন্ট",
+  "customizeYourHostEvent": "আপনার হোস্ট ইভেন্ট কাস্টমাইজ করুন",
+  "hypetrainEventConfigTitle": "হাইপ ট্রেন ইভেন্ট",
+  "customizeYourHypetrainEvent": "আপনার হাইপ ট্রেন ইভেন্ট কাস্টমাইজ করুন"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -112,5 +112,19 @@
   "durationOneDayTimeoutPrompt": "Timeout für 1 tag",
   "durationTwoDaysTimeoutPrompt": "Timeout für 2 tage",
   "durationOneWeekTimeoutPrompt": "Timeout für 1 woche",
-  "durationTwoWeeksTimeoutPrompt": "Timeout für 2 wochen"
+  "durationTwoWeeksTimeoutPrompt": "Timeout für 2 wochen",
+  "errorFetchingViewerList": "Wir konnten die Zuschauerliste für diesen Kanal nicht abrufen",
+  "eventsTitle": "Veranstaltungen",
+  "followEventConfigTitle": "Folgenereignis",
+  "customizeYourFollowEvent": "Passen Sie Ihr Folgeereignis an",
+  "subscribeEventConfigTitle": "Ereignis abonnieren",
+  "customizeYourSubscriptionEvent": "Passen Sie Ihr Abonnementereignis an",
+  "cheerEventConfigTitle": "Jubelereignis",
+  "customizeYourCheerEvent": "Passen Sie Ihr Jubelereignis an",
+  "raidEventConfigTitle": "Raid-Ereignis",
+  "customizeYourRaidEvent": "Passen Sie Ihr Raid-Ereignis an",
+  "hostEventConfigTitle": "Host-Ereignis",
+  "customizeYourHostEvent": "Passen Sie Ihr Host-Ereignis an",
+  "hypetrainEventConfigTitle": "Hypetrain-Ereignis",
+  "customizeYourHypetrainEvent": "Passen Sie Ihr Hypetrain-Ereignis an"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -112,5 +112,19 @@
   "durationOneDayTimeoutPrompt": "Suspender por 1 día",
   "durationTwoDaysTimeoutPrompt": "Suspender por 2 días",
   "durationOneWeekTimeoutPrompt": "Suspender por 1 semana",
-  "durationTwoWeeksTimeoutPrompt": "Suspender por 2 semanas"
+  "durationTwoWeeksTimeoutPrompt": "Suspender por 2 semanas",
+  "errorFetchingViewerList": "No se pudo obtener la lista de espectadores para este canal",
+  "eventsTitle": "Eventos",
+  "followEventConfigTitle": "Evento de seguimiento",
+  "customizeYourFollowEvent": "Personaliza tu evento de seguimiento",
+  "subscribeEventConfigTitle": "Evento de suscripción",
+  "customizeYourSubscriptionEvent": "Personaliza tu evento de suscripción",
+  "cheerEventConfigTitle": "Evento de animación",
+  "customizeYourCheerEvent": "Personaliza tu evento de animación",
+  "raidEventConfigTitle": "Evento de incursión",
+  "customizeYourRaidEvent": "Personaliza tu evento de incursión",
+  "hostEventConfigTitle": "Evento de anfitrión",
+  "customizeYourHostEvent": "Personaliza tu evento de anfitrión",
+  "hypetrainEventConfigTitle": "Evento de tren de hype",
+  "customizeYourHypetrainEvent": "Personaliza tu evento de tren de hype"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -112,5 +112,19 @@
   "durationOneDayTimeoutPrompt": "Délai d'attente pour 1 jour",
   "durationTwoDaysTimeoutPrompt": "Délai d'attente pour 2 jours",
   "durationOneWeekTimeoutPrompt": "Délai d'attente pour 1 semaine",
-  "durationTwoWeeksTimeoutPrompt": "Délai d'attente pour 2 semaines"
+  "durationTwoWeeksTimeoutPrompt": "Délai d'attente pour 2 semaines",
+  "errorFetchingViewerList": "Nous n'avons pas pu récupérer la liste des téléspectateurs pour cette chaîne",
+  "eventsTitle": "Événements",
+  "followEventConfigTitle": "Événement de suivi",
+  "customizeYourFollowEvent": "Personnalisez votre événement de suivi",
+  "subscribeEventConfigTitle": "Événement d'abonnement",
+  "customizeYourSubscriptionEvent": "Personnalisez votre événement d'abonnement",
+  "cheerEventConfigTitle": "Événement de cheer",
+  "customizeYourCheerEvent": "Personnalisez votre événement de cheer",
+  "raidEventConfigTitle": "Événement de raid",
+  "customizeYourRaidEvent": "Personnalisez votre événement de raid",
+  "hostEventConfigTitle": "Événement d'hôte",
+  "customizeYourHostEvent": "Personnalisez votre événement d'hôte",
+  "hypetrainEventConfigTitle": "Événement de train de la hype",
+  "customizeYourHypetrainEvent": "Personnalisez votre événement de train de la hype"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -112,5 +112,19 @@
   "durationOneDayTimeoutPrompt": "1日間タイムアウト",
   "durationTwoDaysTimeoutPrompt": "2日間タイムアウト",
   "durationOneWeekTimeoutPrompt": "1週間タイムアウト",
-  "durationTwoWeeksTimeoutPrompt": "2週間タイムアウト"
+  "durationTwoWeeksTimeoutPrompt": "2週間タイムアウト",
+  "errorFetchingViewerList": "このチャンネルの視聴者リストを取得できませんでした",
+  "eventsTitle": "イベント",
+  "followEventConfigTitle": "フォローイベント",
+  "customizeYourFollowEvent": "フォローイベントをカスタマイズする",
+  "subscribeEventConfigTitle": "サブスクライブイベント",
+  "customizeYourSubscriptionEvent": "サブスクリプションイベントをカスタマイズする",
+  "cheerEventConfigTitle": "チアイベント",
+  "customizeYourCheerEvent": "チアイベントをカスタマイズする",
+  "raidEventConfigTitle": "レイドイベント",
+  "customizeYourRaidEvent": "レイドイベントをカスタマイズする",
+  "hostEventConfigTitle": "ホストイベント",
+  "customizeYourHostEvent": "ホストイベントをカスタマイズする",
+  "hypetrainEventConfigTitle": "ハイプトレインイベント",
+  "customizeYourHypetrainEvent": "ハイプトレインイベントをカスタマイズする"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -112,5 +112,19 @@
   "durationOneDayTimeoutPrompt": "Time-out voor 1 dag",
   "durationTwoDaysTimeoutPrompt": "Time-out voor 2 dagen",
   "durationOneWeekTimeoutPrompt": "Time-out voor 1 week",
-  "durationTwoWeeksTimeoutPrompt": "Time-out voor 2 weken"
+  "durationTwoWeeksTimeoutPrompt": "Time-out voor 2 weken",
+  "errorFetchingViewerList": "We konden de kijkerslijst voor dit kanaal niet ophalen",
+  "eventsTitle": "Evenementen",
+  "followEventConfigTitle": "Volg evenement",
+  "customizeYourFollowEvent": "Pas je volg evenement aan",
+  "subscribeEventConfigTitle": "Abonneer evenement",
+  "customizeYourSubscriptionEvent": "Pas je abonneer evenement aan",
+  "cheerEventConfigTitle": "Juich evenement",
+  "customizeYourCheerEvent": "Pas je juich evenement aan",
+  "raidEventConfigTitle": "Raid evenement",
+  "customizeYourRaidEvent": "Pas je raid evenement aan",
+  "hostEventConfigTitle": "Host evenement",
+  "customizeYourHostEvent": "Pas je host evenement aan",
+  "hypetrainEventConfigTitle": "Hypetrein evenement",
+  "customizeYourHypetrainEvent": "Pas je hypetrein evenement aan"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -113,5 +113,19 @@
   "durationOneDayTimeoutPrompt": "Timeout de 1 dia",
   "durationTwoDaysTimeoutPrompt": "Timeout de 2 dias",
   "durationOneWeekTimeoutPrompt": "Timeout de 1 semana",
-  "durationTwoWeeksTimeoutPrompt": "Timeout de 2 semanas"
+  "durationTwoWeeksTimeoutPrompt": "Timeout de 2 semanas",
+  "errorFetchingViewerList": "Não foi possível buscar a lista de espectadores para este canal",
+  "eventsTitle": "Eventos",
+  "followEventConfigTitle": "Evento de Seguir",
+  "customizeYourFollowEvent": "Personalize seu evento de seguir",
+  "subscribeEventConfigTitle": "Evento de Inscrição",
+  "customizeYourSubscriptionEvent": "Personalize seu evento de inscrição",
+  "cheerEventConfigTitle": "Evento de Torcida",
+  "customizeYourCheerEvent": "Personalize seu evento de torcida",
+  "raidEventConfigTitle": "Evento de Raid",
+  "customizeYourRaidEvent": "Personalize seu evento de raid",
+  "hostEventConfigTitle": "Evento de Host",
+  "customizeYourHostEvent": "Personalize seu evento de host",
+  "hypetrainEventConfigTitle": "Evento de Trem do Hype",
+  "customizeYourHypetrainEvent": "Personalize seu evento de trem do hype"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -112,5 +112,19 @@
   "durationOneDayTimeoutPrompt": "暂停1天",
   "durationTwoDaysTimeoutPrompt": "暂停2天",
   "durationOneWeekTimeoutPrompt": "暂停1周",
-  "durationTwoWeeksTimeoutPrompt": "暂停2周"
+  "durationTwoWeeksTimeoutPrompt": "暂停2周",
+  "errorFetchingViewerList": "我们无法获取此频道的观众列表",
+  "eventsTitle": "事件",
+  "followEventConfigTitle": "关注事件",
+  "customizeYourFollowEvent": "自定义您的关注事件",
+  "subscribeEventConfigTitle": "订阅事件",
+  "customizeYourSubscriptionEvent": "自定义您的订阅事件",
+  "cheerEventConfigTitle": "欢呼事件",
+  "customizeYourCheerEvent": "自定义您的欢呼事件",
+  "raidEventConfigTitle": "突袭事件",
+  "customizeYourRaidEvent": "自定义您的突袭事件",
+  "hostEventConfigTitle": "主持事件",
+  "customizeYourHostEvent": "自定义您的主持事件",
+  "hypetrainEventConfigTitle": "热潮列车事件",
+  "customizeYourHypetrainEvent": "自定义您的热潮列车事件"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -113,5 +113,19 @@
   "durationOneDayTimeoutPrompt": "封鎖1天",
   "durationTwoDaysTimeoutPrompt": "封鎖2天",
   "durationOneWeekTimeoutPrompt": "封鎖1週",
-  "durationTwoWeeksTimeoutPrompt": "封鎖2週"
+  "durationTwoWeeksTimeoutPrompt": "封鎖2週",
+  "errorFetchingViewerList": "我們無法獲取此頻道的觀眾列表",
+  "eventsTitle": "事件",
+  "followEventConfigTitle": "追隨事件",
+  "customizeYourFollowEvent": "自訂您的追隨事件",
+  "subscribeEventConfigTitle": "訂閱事件",
+  "customizeYourSubscriptionEvent": "自訂您的訂閱事件",
+  "cheerEventConfigTitle": "歡呼事件",
+  "customizeYourCheerEvent": "自訂您的歡呼事件",
+  "raidEventConfigTitle": "突襲事件",
+  "customizeYourRaidEvent": "自訂您的突襲事件",
+  "hostEventConfigTitle": "主持事件",
+  "customizeYourHostEvent": "自訂您的主持事件",
+  "hypetrainEventConfigTitle": "熱潮列車事件",
+  "customizeYourHypetrainEvent": "自訂您的熱潮列車事件"
 }


### PR DESCRIPTION
Add translations for various event-related strings in multiple languages.

* **Add translations in `lib/l10n/app_bn.arb`**:
  - Add translations for `errorFetchingViewerList`, `eventsTitle`, `followEventConfigTitle`, `customizeYourFollowEvent`, `subscribeEventConfigTitle`, `customizeYourSubscriptionEvent`, `cheerEventConfigTitle`, `customizeYourCheerEvent`, `raidEventConfigTitle`, `customizeYourRaidEvent`, `hostEventConfigTitle`, `customizeYourHostEvent`, `hypetrainEventConfigTitle`, and `customizeYourHypetrainEvent`.

* **Add translations in `lib/l10n/app_de.arb`**:
  - Add translations for `errorFetchingViewerList`, `eventsTitle`, `followEventConfigTitle`, `customizeYourFollowEvent`, `subscribeEventConfigTitle`, `customizeYourSubscriptionEvent`, `cheerEventConfigTitle`, `customizeYourCheerEvent`, `raidEventConfigTitle`, `customizeYourRaidEvent`, `hostEventConfigTitle`, `customizeYourHostEvent`, `hypetrainEventConfigTitle`, and `customizeYourHypetrainEvent`.

* **Add translations in `lib/l10n/app_es.arb`**:
  - Add translations for `errorFetchingViewerList`, `eventsTitle`, `followEventConfigTitle`, `customizeYourFollowEvent`, `subscribeEventConfigTitle`, `customizeYourSubscriptionEvent`, `cheerEventConfigTitle`, `customizeYourCheerEvent`, `raidEventConfigTitle`, `customizeYourRaidEvent`, `hostEventConfigTitle`, `customizeYourHostEvent`, `hypetrainEventConfigTitle`, and `customizeYourHypetrainEvent`.

* **Add translations in `lib/l10n/app_fr.arb`**:
  - Add translations for `errorFetchingViewerList`, `eventsTitle`, `followEventConfigTitle`, `customizeYourFollowEvent`, `subscribeEventConfigTitle`, `customizeYourSubscriptionEvent`, `cheerEventConfigTitle`, `customizeYourCheerEvent`, `raidEventConfigTitle`, `customizeYourRaidEvent`, `hostEventConfigTitle`, `customizeYourHostEvent`, `hypetrainEventConfigTitle`, and `customizeYourHypetrainEvent`.

* **Add translations in `lib/l10n/app_ja.arb`**:
  - Add translations for `errorFetchingViewerList`, `eventsTitle`, `followEventConfigTitle`, `customizeYourFollowEvent`, `subscribeEventConfigTitle`, `customizeYourSubscriptionEvent`, `cheerEventConfigTitle`, `customizeYourCheerEvent`, `raidEventConfigTitle`, `customizeYourRaidEvent`, `hostEventConfigTitle`, `customizeYourHostEvent`, `hypetrainEventConfigTitle`, and `customizeYourHypetrainEvent`.

* **Add translations in `lib/l10n/app_nl.arb`**:
  - Add translations for `errorFetchingViewerList`, `eventsTitle`, `followEventConfigTitle`, `customizeYourFollowEvent`, `subscribeEventConfigTitle`, `customizeYourSubscriptionEvent`, `cheerEventConfigTitle`, `customizeYourCheerEvent`, `raidEventConfigTitle`, `customizeYourRaidEvent`, `hostEventConfigTitle`, `customizeYourHostEvent`, `hypetrainEventConfigTitle`, and `customizeYourHypetrainEvent`.

* **Add translations in `lib/l10n/app_pt.arb`**:
  - Add translations for `errorFetchingViewerList`, `eventsTitle`, `followEventConfigTitle`, `customizeYourFollowEvent`, `subscribeEventConfigTitle`, `customizeYourSubscriptionEvent`, `cheerEventConfigTitle`, `customizeYourCheerEvent`, `raidEventConfigTitle`, `customizeYourRaidEvent`, `hostEventConfigTitle`, `customizeYourHostEvent`, `hypetrainEventConfigTitle`, and `customizeYourHypetrainEvent`.

* **Add translations in `lib/l10n/app_zh_Hant.arb`**:
  - Add translations for `errorFetchingViewerList`, `eventsTitle`, `followEventConfigTitle`, `customizeYourFollowEvent`, `subscribeEventConfigTitle`, `customizeYourSubscriptionEvent`, `cheerEventConfigTitle`, `customizeYourCheerEvent`, `raidEventConfigTitle`, `customizeYourRaidEvent`, `hostEventConfigTitle`, `customizeYourHostEvent`, `hypetrainEventConfigTitle`, and `customizeYourHypetrainEvent`.

* **Add translations in `lib/l10n/app_zh.arb`**:
  - Add translations for `errorFetchingViewerList`, `eventsTitle`, `followEventConfigTitle`, `customizeYourFollowEvent`, `subscribeEventConfigTitle`, `customizeYourSubscriptionEvent`, `cheerEvent
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat?shareId=bf97284e-dce3-4a8f-9643-9cdab8de2521).