### PR TITLE
Add translations for various event messages

### DIFF
--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -148,5 +148,13 @@
   "realtimeCashDonationWithDonor": "<b>{donor}</b> <b>{value} {currency}</b> দান করেছে।",
   "realtimeCashDonationAnonymous": "বেনামী <b>{value} {currency}</b> দান করেছে।",
   "streamElementsTipEventMessage": "<b>{name}</b> StreamElements এ <b>{formattedAmount}</b> টিপ দিয়েছে।",
-  "streamlabsDonationEventMessage": "<b>{name}</b> Streamlabs এ <b>{formattedAmount}</b> টিপ দিয়েছে।"
+  "streamlabsDonationEventMessage": "<b>{name}</b> Streamlabs এ <b>{formattedAmount}</b> টিপ দিয়েছে।",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> <b>{rewardName}</b> <b>{rewardCost}</b> পয়েন্টের জন্য রিডিম করেছে। {userInput}",
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> <b>{rewardName}</b> <b>{rewardCost}</b> পয়েন্টের জন্য রিডিম করেছে।",
+  "cheerEventMessage": "<b>{name}</b> <b>{bits}</b> বিটস চিয়ার করেছে। {cheerMessage}",
+  "anonymous": "বেনামী",
+  "hostEventMessage": "<b>{fromDisplayName}</b> <b>{viewers}</b> জনের পার্টি নিয়ে হোস্ট করছে।",
+  "hypeTrainEventProgress": "হাইপ ট্রেন লেভেল <b>{level}</b> চলছে! <b>{progressPercent}%</b> সম্পন্ন হয়েছে!",
+  "hypeTrainEventEndedSuccessful": "হাইপ ট্রেন লেভেল <b>{level}</b> সফল হয়েছে।",
+  "hypeTrainEventEndedUnsuccessful": "হাইপ ট্রেন লেভেল <b>{level}</b> ব্যর্থ হয়েছে।"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -148,5 +148,13 @@
   "realtimeCashDonationWithDonor": "<b>{donor}</b> hat <b>{value} {currency}</b> gespendet.",
   "realtimeCashDonationAnonymous": "Anonym hat <b>{value} {currency}</b> gespendet.",
   "streamElementsTipEventMessage": "<b>{name}</b> hat <b>{formattedAmount}</b> auf StreamElements getippt.",
-  "streamlabsDonationEventMessage": "<b>{name}</b> hat <b>{formattedAmount}</b> auf Streamlabs getippt."
+  "streamlabsDonationEventMessage": "<b>{name}</b> hat <b>{formattedAmount}</b> auf Streamlabs getippt.",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> hat <b>{rewardName}</b> für <b>{rewardCost}</b> Punkte eingelöst. {userInput}",
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> hat <b>{rewardName}</b> für <b>{rewardCost}</b> Punkte eingelöst.",
+  "cheerEventMessage": "<b>{name}</b> hat <b>{bits}</b> Bits gejubelt. {cheerMessage}",
+  "anonymous": "Anonym",
+  "hostEventMessage": "<b>{fromDisplayName}</b> hostet mit einer Party von <b>{viewers}</b>.",
+  "hypeTrainEventProgress": "Hype Train Level <b>{level}</b> in Bearbeitung! <b>{progressPercent}%</b> abgeschlossen!",
+  "hypeTrainEventEndedSuccessful": "Hype Train Level <b>{level}</b> erfolgreich abgeschlossen.",
+  "hypeTrainEventEndedUnsuccessful": "Hype Train Level <b>{level}</b> nicht erfolgreich abgeschlossen."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -148,5 +148,13 @@
   "realtimeCashDonationWithDonor": "<b>{donor}</b> ha donado <b>{value} {currency}</b>.",
   "realtimeCashDonationAnonymous": "Anónimo ha donado <b>{value} {currency}</b>.",
   "streamElementsTipEventMessage": "<b>{name}</b> ha dado una propina de <b>{formattedAmount}</b> en StreamElements.",
-  "streamlabsDonationEventMessage": "<b>{name}</b> ha dado una propina de <b>{formattedAmount}</b> en Streamlabs."
+  "streamlabsDonationEventMessage": "<b>{name}</b> ha dado una propina de <b>{formattedAmount}</b> en Streamlabs.",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> canjeó <b>{rewardName}</b> por <b>{rewardCost}</b> puntos. {userInput}",
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> canjeó <b>{rewardName}</b> por <b>{rewardCost}</b> puntos.",
+  "cheerEventMessage": "<b>{name}</b> animó con <b>{bits}</b> bits. {cheerMessage}",
+  "anonymous": "Anónimo",
+  "hostEventMessage": "<b>{fromDisplayName}</b> está alojando con un grupo de <b>{viewers}</b>.",
+  "hypeTrainEventProgress": "¡El tren del hype nivel <b>{level}</b> está en progreso! ¡<b>{progressPercent}%</b> completado!",
+  "hypeTrainEventEndedSuccessful": "El tren del hype nivel <b>{level}</b> ha tenido éxito.",
+  "hypeTrainEventEndedUnsuccessful": "El tren del hype nivel <b>{level}</b> ha fallado."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -148,5 +148,13 @@
   "realtimeCashDonationWithDonor": "<b>{donor}</b> a fait un don de <b>{value} {currency}</b>.",
   "realtimeCashDonationAnonymous": "Anonyme a fait un don de <b>{value} {currency}</b>.",
   "streamElementsTipEventMessage": "<b>{name}</b> a donné un pourboire de <b>{formattedAmount}</b> sur StreamElements.",
-  "streamlabsDonationEventMessage": "<b>{name}</b> a donné un pourboire de <b>{formattedAmount}</b> sur Streamlabs."
+  "streamlabsDonationEventMessage": "<b>{name}</b> a donné un pourboire de <b>{formattedAmount}</b> sur Streamlabs.",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> a échangé <b>{rewardName}</b> contre <b>{rewardCost}</b> points. {userInput}",
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> a échangé <b>{rewardName}</b> contre <b>{rewardCost}</b> points.",
+  "cheerEventMessage": "<b>{name}</b> a acclamé <b>{bits}</b> bits. {cheerMessage}",
+  "anonymous": "Anonyme",
+  "hostEventMessage": "<b>{fromDisplayName}</b> héberge avec un groupe de <b>{viewers}</b>.",
+  "hypeTrainEventProgress": "Le train de la hype de niveau <b>{level}</b> est en cours ! <b>{progressPercent}%</b> terminé !",
+  "hypeTrainEventEndedSuccessful": "Le train de la hype de niveau <b>{level}</b> a réussi.",
+  "hypeTrainEventEndedUnsuccessful": "Le train de la hype de niveau <b>{level}</b> a échoué."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -148,5 +148,13 @@
   "realtimeCashDonationWithDonor": "<b>{donor}</b>が<b>{value}{currency}</b>を寄付しました。",
   "realtimeCashDonationAnonymous": "匿名が<b>{value}{currency}</b>を寄付しました。",
   "streamElementsTipEventMessage": "<b>{name}</b>がStreamElementsで<b>{formattedAmount}</b>をチップしました。",
-  "streamlabsDonationEventMessage": "<b>{name}</b>がStreamlabsで<b>{formattedAmount}</b>をチップしました。"
+  "streamlabsDonationEventMessage": "<b>{name}</b>がStreamlabsで<b>{formattedAmount}</b>をチップしました。",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> が <b>{rewardName}</b> を <b>{rewardCost}</b> ポイントで交換しました。 {userInput}",
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> が <b>{rewardName}</b> を <b>{rewardCost}</b> ポイントで交換しました。",
+  "cheerEventMessage": "<b>{name}</b> が <b>{bits}</b> ビッツをチアーしました。 {cheerMessage}",
+  "anonymous": "匿名",
+  "hostEventMessage": "<b>{fromDisplayName}</b> が <b>{viewers}</b> 人のパーティーでホストしています。",
+  "hypeTrainEventProgress": "ハイプトレインレベル <b>{level}</b> が進行中です！ <b>{progressPercent}%</b> 完了しました！",
+  "hypeTrainEventEndedSuccessful": "ハイプトレインレベル <b>{level}</b> が成功しました。",
+  "hypeTrainEventEndedUnsuccessful": "ハイプトレインレベル <b>{level}</b> が失敗しました。"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -148,5 +148,13 @@
   "realtimeCashDonationWithDonor": "<b>{donor}</b> heeft <b>{value} {currency}</b> gedoneerd.",
   "realtimeCashDonationAnonymous": "Anoniem heeft <b>{value} {currency}</b> gedoneerd.",
   "streamElementsTipEventMessage": "<b>{name}</b> heeft <b>{formattedAmount}</b> getipt op StreamElements.",
-  "streamlabsDonationEventMessage": "<b>{name}</b> heeft <b>{formattedAmount}</b> getipt op Streamlabs."
+  "streamlabsDonationEventMessage": "<b>{name}</b> heeft <b>{formattedAmount}</b> getipt op Streamlabs.",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> heeft <b>{rewardName}</b> ingewisseld voor <b>{rewardCost}</b> punten. {userInput}",
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> heeft <b>{rewardName}</b> ingewisseld voor <b>{rewardCost}</b> punten.",
+  "cheerEventMessage": "<b>{name}</b> heeft <b>{bits}</b> bits gejuicht. {cheerMessage}",
+  "anonymous": "Anoniem",
+  "hostEventMessage": "<b>{fromDisplayName}</b> is aan het hosten met een groep van <b>{viewers}</b> kijkers.",
+  "hypeTrainEventProgress": "Hypetrein level <b>{level}</b> is bezig! <b>{progressPercent}%</b> voltooid!",
+  "hypeTrainEventEndedSuccessful": "Hypetrein level <b>{level}</b> is geslaagd.",
+  "hypeTrainEventEndedUnsuccessful": "Hypetrein level <b>{level}</b> is mislukt."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -149,5 +149,13 @@
   "realtimeCashDonationWithDonor": "<b>{donor}</b> doou <b>{value} {currency}</b>.",
   "realtimeCashDonationAnonymous": "Anônimo doou <b>{value} {currency}</b>.",
   "streamElementsTipEventMessage": "<b>{name}</b> deu uma gorjeta de <b>{formattedAmount}</b> no StreamElements.",
-  "streamlabsDonationEventMessage": "<b>{name}</b> deu uma gorjeta de <b>{formattedAmount}</b> no Streamlabs."
+  "streamlabsDonationEventMessage": "<b>{name}</b> deu uma gorjeta de <b>{formattedAmount}</b> no Streamlabs.",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> resgatou <b>{rewardName}</b> por <b>{rewardCost}</b> pontos. {userInput}",
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> resgatou <b>{rewardName}</b> por <b>{rewardCost}</b> pontos.",
+  "cheerEventMessage": "<b>{name}</b> torceu <b>{bits}</b> bits. {cheerMessage}",
+  "anonymous": "Anônimo",
+  "hostEventMessage": "<b>{fromDisplayName}</b> está hospedando com um grupo de <b>{viewers}</b> espectadores.",
+  "hypeTrainEventProgress": "Trem do Hype nível <b>{level}</b> em andamento! <b>{progressPercent}%</b> concluído!",
+  "hypeTrainEventEndedSuccessful": "Trem do Hype nível <b>{level}</b> concluído com sucesso.",
+  "hypeTrainEventEndedUnsuccessful": "Trem do Hype nível <b>{level}</b> falhou."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -148,5 +148,13 @@
   "realtimeCashDonationWithDonor": "<b>{donor}</b> 捐赠了 <b>{value} {currency}</b>。",
   "realtimeCashDonationAnonymous": "匿名捐赠了 <b>{value} {currency}</b>。",
   "streamElementsTipEventMessage": "<b>{name}</b> 在 StreamElements 上打赏了 <b>{formattedAmount}</b>。",
-  "streamlabsDonationEventMessage": "<b>{name}</b> 在 Streamlabs 上打赏了 <b>{formattedAmount}</b>。"
+  "streamlabsDonationEventMessage": "<b>{name}</b> 在 Streamlabs 上打赏了 <b>{formattedAmount}</b>。",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> 兑换了 <b>{rewardName}</b>，花费了 <b>{rewardCost}</b> 点数。{userInput}",
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> 兑换了 <b>{rewardName}</b>，花费了 <b>{rewardCost}</b> 点数。",
+  "cheerEventMessage": "<b>{name}</b> 欢呼了 <b>{bits}</b> 点。{cheerMessage}",
+  "anonymous": "匿名",
+  "hostEventMessage": "<b>{fromDisplayName}</b> 正在主持，带着 <b>{viewers}</b> 位观众。",
+  "hypeTrainEventProgress": "热潮列车等級 <b>{level}</b> 進行中！已完成 <b>{progressPercent}%</b>！",
+  "hypeTrainEventEndedSuccessful": "热潮列车等級 <b>{level}</b> 成功。",
+  "hypeTrainEventEndedUnsuccessful": "热潮列车等級 <b>{level}</b> 失敗。"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -149,5 +149,13 @@
   "realtimeCashDonationWithDonor": "<b>{donor}</b> 捐贈了 <b>{value} {currency}</b>。",
   "realtimeCashDonationAnonymous": "匿名捐贈了 <b>{value} {currency}</b>。",
   "streamElementsTipEventMessage": "<b>{name}</b> 在 StreamElements 上打賞了 <b>{formattedAmount}</b>。",
-  "streamlabsDonationEventMessage": "<b>{name}</b> 在 Streamlabs 上打賞了 <b>{formattedAmount}</b>。"
+  "streamlabsDonationEventMessage": "<b>{name}</b> 在 Streamlabs 上打賞了 <b>{formattedAmount}</b>。",
+  "channelPointRedemptionWithUserInput": "<b>{redeemerUsername}</b> 兌換了 <b>{rewardName}</b>，花費了 <b>{rewardCost}</b> 點數。{userInput}",
+  "channelPointRedemptionWithoutUserInput": "<b>{redeemerUsername}</b> 兌換了 <b>{rewardName}</b>，花費了 <b>{rewardCost}</b> 點數。",
+  "cheerEventMessage": "<b>{name}</b> 歡呼了 <b>{bits}</b> 點。{cheerMessage}",
+  "anonymous": "匿名",
+  "hostEventMessage": "<b>{fromDisplayName}</b> 正在主持，帶著 <b>{viewers}</b> 位觀眾。",
+  "hypeTrainEventProgress": "熱潮列車等級 <b>{level}</b> 進行中！已完成 <b>{progressPercent}%</b>！",
+  "hypeTrainEventEndedSuccessful": "熱潮列車等級 <b>{level}</b> 成功。",
+  "hypeTrainEventEndedUnsuccessful": "熱潮列車等級 <b>{level}</b> 失敗。"
 }


### PR DESCRIPTION
Add translations for various event messages in multiple language files.

* **Bengali (app_bn.arb)**
  - Add translations for `channelPointRedemptionWithUserInput`, `channelPointRedemptionWithoutUserInput`, `cheerEventMessage`, `anonymous`, `hostEventMessage`, `hypeTrainEventProgress`, `hypeTrainEventEndedSuccessful`, and `hypeTrainEventEndedUnsuccessful`.

* **German (app_de.arb)**
  - Add translations for `channelPointRedemptionWithUserInput`, `channelPointRedemptionWithoutUserInput`, `cheerEventMessage`, `anonymous`, `hostEventMessage`, `hypeTrainEventProgress`, `hypeTrainEventEndedSuccessful`, and `hypeTrainEventEndedUnsuccessful`.

* **Spanish (app_es.arb)**
  - Add translations for `channelPointRedemptionWithUserInput`, `channelPointRedemptionWithoutUserInput`, `cheerEventMessage`, `anonymous`, `hostEventMessage`, `hypeTrainEventProgress`, `hypeTrainEventEndedSuccessful`, and `hypeTrainEventEndedUnsuccessful`.

* **French (app_fr.arb)**
  - Add translations for `channelPointRedemptionWithUserInput`, `channelPointRedemptionWithoutUserInput`, `cheerEventMessage`, `anonymous`, `hostEventMessage`, `hypeTrainEventProgress`, `hypeTrainEventEndedSuccessful`, and `hypeTrainEventEndedUnsuccessful`.

* **Japanese (app_ja.arb)**
  - Add translations for `channelPointRedemptionWithUserInput`, `channelPointRedemptionWithoutUserInput`, `cheerEventMessage`, `anonymous`, `hostEventMessage`, `hypeTrainEventProgress`, `hypeTrainEventEndedSuccessful`, and `hypeTrainEventEndedUnsuccessful`.

* **Dutch (app_nl.arb)**
  - Add translations for `channelPointRedemptionWithUserInput`, `channelPointRedemptionWithoutUserInput`, `cheerEventMessage`, `anonymous`, `hostEventMessage`, `hypeTrainEventProgress`, `hypeTrainEventEndedSuccessful`, and `hypeTrainEventEndedUnsuccessful`.

* **Portuguese (app_pt.arb)**
  - Add translations for `channelPointRedemptionWithUserInput`, `channelPointRedemptionWithoutUserInput`, `cheerEventMessage`, `anonymous`, `hostEventMessage`, `hypeTrainEventProgress`, `hypeTrainEventEndedSuccessful`, and `hypeTrainEventEndedUnsuccessful`.

* **Traditional Chinese (app_zh_Hant.arb)**
  - Add translations for `channelPointRedemptionWithUserInput`, `channelPointRedemptionWithoutUserInput`, `cheerEventMessage`, `anonymous`, `hostEventMessage`, `hypeTrainEventProgress`, `hypeTrainEventEndedSuccessful`, and `hypeTrainEventEndedUnsuccessful`.

* **Simplified Chinese (app_zh.arb)**
  - Add translations for `channelPointRedemptionWithUserInput`, `channelPointRedemptionWithoutUserInput`, `cheerEventMessage`, `anonymous`, `hostEventMessage`, `hypeTrainEventProgress`, `hypeTrainEventEndedSuccessful`, and `hypeTrainEventEndedUnsuccessful`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat?shareId=9b7ec783-13e1-49b2-96e0-e884d2aad8dd).