### PR TITLE
fix: emote/keyboard overflow and picker

### DIFF
--- a/lib/components/emote_picker.dart
+++ b/lib/components/emote_picker.dart
@@ -58,7 +58,7 @@ class EmotesList extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 16.0),
             alignment: Alignment.centerLeft,
             child: Padding(
-              padding: const EdgeInsets.only(top: 16.0, bottom: 8.0),
+              padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
               child: Text(
                 categories[index],
                 style: TextStyle(
@@ -81,14 +81,19 @@ class EmotesList extends StatelessWidget {
                   return Tooltip(
                     message: emote.code,
                     preferBelow: false,
-                    child: IconButton(
-                      onPressed: () => onEmoteSelected(emote),
-                      splashRadius: 24,
-                      icon: CrossFadeImage(
-                        placeholder: emote.image.placeholderImage,
-                        image: emote.image,
-                        width: 36,
-                        height: 36,
+                    child: SizedBox(
+                      // Adjust width for 7 emotes per row
+                      width: (MediaQuery.of(context).size.width - 32) / 7 - 8,
+                      height: 36,
+                      child: IconButton(
+                        onPressed: () => onEmoteSelected(emote),
+                        splashRadius: 24,
+                        icon: CrossFadeImage(
+                          placeholder: emote.image.placeholderImage,
+                          image: emote.image,
+                          width: 36,
+                          height: 36,
+                        ),
                       ),
                     ),
                   );
@@ -130,35 +135,44 @@ class _TabbedEmotePickerWidget extends StatelessWidget {
       if (byProvider.containsKey("7tv")) const Tab(text: "7TV"),
     ];
     return DefaultTabController(
-        length: tabs.length,
-        child: Column(mainAxisAlignment: MainAxisAlignment.end, children: [
+      length: tabs.length,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
           TabBar(tabs: tabs),
           Expanded(
-              child: TabBarView(
-            children: [
-              if (byProvider.containsKey("twitch"))
-                EmotesList(
+            child: TabBarView(
+              children: [
+                if (byProvider.containsKey("twitch"))
+                  EmotesList(
                     emotes: byProvider["twitch"]!,
                     onEmoteSelected: onEmoteSelected,
-                    channel: channel),
-              if (byProvider.containsKey("bttv"))
-                EmotesList(
+                    channel: channel,
+                  ),
+                if (byProvider.containsKey("bttv"))
+                  EmotesList(
                     emotes: byProvider["bttv"]!,
                     onEmoteSelected: onEmoteSelected,
-                    channel: channel),
-              if (byProvider.containsKey("ffz"))
-                EmotesList(
+                    channel: channel,
+                  ),
+                if (byProvider.containsKey("ffz"))
+                  EmotesList(
                     emotes: byProvider["ffz"]!,
                     onEmoteSelected: onEmoteSelected,
-                    channel: channel),
-              if (byProvider.containsKey("7tv"))
-                EmotesList(
+                    channel: channel,
+                  ),
+                if (byProvider.containsKey("7tv"))
+                  EmotesList(
                     emotes: byProvider["7tv"]!,
                     onEmoteSelected: onEmoteSelected,
-                    channel: channel),
-            ],
-          )),
-        ]));
+                    channel: channel,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 
@@ -166,8 +180,11 @@ class EmotePickerWidget extends StatelessWidget {
   final void Function(Emote?) onEmoteSelected;
   final Channel channel;
 
-  const EmotePickerWidget(
-      {super.key, required this.onEmoteSelected, required this.channel});
+  const EmotePickerWidget({
+    super.key,
+    required this.onEmoteSelected,
+    required this.channel,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -183,17 +200,19 @@ class EmotePickerWidget extends StatelessWidget {
       child: SizedBox(
         height: min(48 * rowNumber.toDouble(), maxHeight),
         child: FutureBuilder<List<Emote>>(
-            future: getEmotes(channel),
-            initialData: const [],
-            builder: (context, snapshot) {
-              if (snapshot.connectionState != ConnectionState.done) {
-                return const Center(child: CircularProgressIndicator());
-              }
-              return _TabbedEmotePickerWidget(
-                  emotes: snapshot.data!,
-                  onEmoteSelected: onEmoteSelected,
-                  channel: channel);
-            }),
+          future: getEmotes(channel),
+          initialData: const [],
+          builder: (context, snapshot) {
+            if (snapshot.connectionState != ConnectionState.done) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            return _TabbedEmotePickerWidget(
+              emotes: snapshot.data!,
+              onEmoteSelected: onEmoteSelected,
+              channel: channel,
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -150,11 +150,12 @@ class HomeScreen extends StatefulWidget {
   final Channel channel;
   final void Function(Channel) onChannelSelect;
 
-  const HomeScreen(
-      {required this.isDiscoModeEnabled,
-      required this.channel,
-      required this.onChannelSelect,
-      super.key});
+  const HomeScreen({
+    required this.isDiscoModeEnabled,
+    required this.channel,
+    required this.onChannelSelect,
+    super.key,
+  });
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
@@ -162,6 +163,7 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
+
   @override
   void initState() {
     super.initState();
@@ -198,15 +200,14 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     final width = mediaQuery.size.width;
 
     return GestureDetector(
-        onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-        child: Consumer<UserModel>(builder: (context, userModel, child) {
+      onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+      child: Consumer<UserModel>(
+        builder: (context, userModel, child) {
           return Scaffold(
             key: _scaffoldKey,
             drawer: Sidebar(channel: widget.channel),
             endDrawer: userModel.isSignedIn()
-                ? EndDrawerWidget(
-                    channel: widget.channel,
-                  )
+                ? EndDrawerWidget(channel: widget.channel)
                 : null,
             drawerEdgeDragWidth: MediaQuery.of(context).size.width * 0.6,
             onDrawerChanged: (isOpened) =>
@@ -214,11 +215,11 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
             onEndDrawerChanged: (isOpened) =>
                 FocusManager.instance.primaryFocus?.unfocus(),
             appBar: HeaderBarWidget(
-                onChannelSelect: widget.onChannelSelect,
-                channel: widget.channel,
-                actions: [
-                  Consumer2<ActivityFeedModel, LayoutModel>(builder:
-                      (context, activityFeedModel, layoutModel, child) {
+              onChannelSelect: widget.onChannelSelect,
+              channel: widget.channel,
+              actions: [
+                Consumer2<ActivityFeedModel, LayoutModel>(
+                  builder: (context, activityFeedModel, layoutModel, child) {
                     if (!activityFeedModel.isEnabled) {
                       return Container();
                     }
@@ -232,10 +233,11 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                             !layoutModel.isShowNotifications;
                       },
                     );
-                  }),
-                  if (width > 256)
-                    Consumer<LayoutModel>(
-                        builder: (context, layoutModel, child) {
+                  },
+                ),
+                if (width > 256)
+                  Consumer<LayoutModel>(
+                    builder: (context, layoutModel, child) {
                       return IconButton(
                         icon: Icon(layoutModel.isShowPreview
                             ? Icons.preview
@@ -246,185 +248,212 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                               !layoutModel.isShowPreview;
                         },
                       );
-                    }),
-                  Consumer<TtsModel>(
-                    builder: (context, ttsModel, child) {
-                      return IconButton(
-                        icon: Icon(
-                          !kDebugMode
-                              ? (ttsModel.enabled
-                                  ? Icons.record_voice_over
-                                  : Icons.voice_over_off)
-                              : (ttsModel.newTtsEnabled
-                                  ? Icons.record_voice_over
-                                  : Icons.voice_over_off),
-                        ),
-                        tooltip: AppLocalizations.of(context)!.textToSpeech,
-                        onPressed: () async {
-                          if (!kDebugMode) {
-                            ttsModel.enabled = !ttsModel.enabled;
-                          } else {
-                            // Toggle newTtsEnabled and notify listeners immediately
-                            ttsModel.newTtsEnabled = !ttsModel.newTtsEnabled;
-
-                            if (!ttsModel.newTtsEnabled) {
-                              updateChannelSubscription("");
-                              await TextToSpeechPlugin.speak(
-                                  "Text to speech disabled");
-                              await TextToSpeechPlugin.disableTTS();
-                              NotificationsPlugin.cancelNotification();
-                            } else {
-                              // Start listening to the stream before toggling newTtsEnabled
-                              channelStreamController.stream
-                                  .listen((currentChannel) {
-                                if (currentChannel.isEmpty) {
-                                  ttsModel.newTtsEnabled = false;
-                                }
-                              });
-                              await TextToSpeechPlugin.speak(
-                                  "Text to speech enabled");
-                              updateChannelSubscription(
-                                "${userModel.activeChannel?.provider}:${userModel.activeChannel?.channelId}",
-                              );
-                              NotificationsPlugin.showNotification();
-                              NotificationsPlugin.listenToTTs(ttsModel);
-                            }
-                          }
-                        },
-                      );
                     },
                   ),
-                  if (userModel.isSignedIn() && width > 256)
-                    IconButton(
-                      icon: const Icon(Icons.people),
-                      tooltip: AppLocalizations.of(context)!.currentViewers,
-                      onPressed: () {
-                        _scaffoldKey.currentState?.openEndDrawer();
+                Consumer<TtsModel>(
+                  builder: (context, ttsModel, child) {
+                    return IconButton(
+                      icon: Icon(
+                        !kDebugMode
+                            ? (ttsModel.enabled
+                                ? Icons.record_voice_over
+                                : Icons.voice_over_off)
+                            : (ttsModel.newTtsEnabled
+                                ? Icons.record_voice_over
+                                : Icons.voice_over_off),
+                      ),
+                      tooltip: AppLocalizations.of(context)!.textToSpeech,
+                      onPressed: () async {
+                        if (!kDebugMode) {
+                          ttsModel.enabled = !ttsModel.enabled;
+                          // Toggle newTtsEnabled and notify listeners immediately
+                        } else {
+                          ttsModel.newTtsEnabled = !ttsModel.newTtsEnabled;
+
+                          if (!ttsModel.newTtsEnabled) {
+                            updateChannelSubscription("");
+                            await TextToSpeechPlugin.speak(
+                                "Text to speech disabled");
+                            await TextToSpeechPlugin.disableTTS();
+                            NotificationsPlugin.cancelNotification();
+                          } else {
+                            // Start listening to the stream before toggling newTtsEnabled
+                            channelStreamController.stream
+                                .listen((currentChannel) {
+                              if (currentChannel.isEmpty) {
+                                ttsModel.newTtsEnabled = false;
+                              }
+                            });
+                            await TextToSpeechPlugin.speak(
+                                "Text to speech enabled");
+                            updateChannelSubscription(
+                              "${userModel.activeChannel?.provider}:${userModel.activeChannel?.channelId}",
+                            );
+                            NotificationsPlugin.showNotification();
+                            NotificationsPlugin.listenToTTs(ttsModel);
+                          }
+                        }
                       },
-                    ),
-                ]),
+                    );
+                  },
+                ),
+                if (userModel.isSignedIn() && width > 256)
+                  IconButton(
+                    icon: const Icon(Icons.people),
+                    tooltip: AppLocalizations.of(context)!.currentViewers,
+                    onPressed: () {
+                      _scaffoldKey.currentState?.openEndDrawer();
+                    },
+                  ),
+              ],
+            ),
             body: Container(
-              height: MediaQuery.of(context).size.height,
+              height: mediaQuery.size.height,
               color: Theme.of(context).scaffoldBackgroundColor,
               child: SafeArea(
-                child: Builder(builder: (context) {
-                  final chatPanelFooter = Consumer<LayoutModel>(
-                    builder: (context, layoutModel, child) {
-                      return layoutModel.locked ? Container() : child!;
-                    },
-                    child: Builder(
-                      builder: (context) {
-                        if (!userModel.isSignedIn()) {
-                          return Column(children: [
-                            Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  const Flexible(child: Divider()),
-                                  Padding(
+                child: Builder(
+                  builder: (context) {
+                    final chatPanelFooter = Consumer<LayoutModel>(
+                      builder: (context, layoutModel, child) {
+                        return layoutModel.locked ? Container() : child!;
+                      },
+                      child: Builder(
+                        builder: (context) {
+                          if (!userModel.isSignedIn()) {
+                            return Column(
+                              children: [
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    const Flexible(child: Divider()),
+                                    Padding(
                                       padding: const EdgeInsets.all(8),
                                       child: Text(
-                                          AppLocalizations.of(context)!
-                                              .signInToSendMessages,
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .labelLarge)),
-                                  const Flexible(child: Divider()),
-                                ]),
-                            const SignInWithTwitch(),
-                          ]);
-                        }
+                                        AppLocalizations.of(context)!
+                                            .signInToSendMessages,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .labelLarge,
+                                      ),
+                                    ),
+                                    const Flexible(child: Divider()),
+                                  ],
+                                ),
+                                const SignInWithTwitch(),
+                              ],
+                            );
+                          }
 
-                        return MessageInputWidget(
-                          channel: widget.channel,
-                        );
-                      },
-                    ),
-                  );
-                  if (orientation == Orientation.portrait) {
-                    return Consumer<LayoutModel>(
+                          return MessageInputWidget(
+                            channel: widget.channel,
+                          );
+                        },
+                      ),
+                    );
+                    if (orientation == Orientation.portrait) {
+                      return Consumer<LayoutModel>(
                         builder: (context, layoutModel, child) {
-                      return Column(
-                          verticalDirection: VerticalDirection.up,
-                          children: [
-                            // reversed direction because of verticalDirection: VerticalDirection.up
-                            chatPanelFooter,
-
-                            Expanded(
+                          return Column(
+                            verticalDirection: VerticalDirection.up,
+                            children: [
+                              // reversed direction because of verticalDirection: VerticalDirection.up
+                              chatPanelFooter,
+                              Expanded(
                                 child: DiscoWidget(
+                                  isEnabled: widget.isDiscoModeEnabled,
+                                  child:
+                                      ChatPanelWidget(channel: widget.channel),
+                                ),
+                              ),
+                              Consumer<LayoutModel>(
+                                builder: (context, layoutModel, child) {
+                                  if (layoutModel.isShowNotifications) {
+                                    return ResizableWidget(
+                                      resizable: !layoutModel.locked,
+                                      height: layoutModel.panelHeight,
+                                      width: layoutModel.panelWidth,
+                                      onResizeHeight: (height) {
+                                        layoutModel.panelHeight = height;
+                                      },
+                                      onResizeWidth: (width) {
+                                        layoutModel.panelWidth = width;
+                                      },
+                                      child: const ActivityFeedPanelWidget(),
+                                    );
+                                  } else if (layoutModel.isShowPreview) {
+                                    return AspectRatio(
+                                      aspectRatio: 16 / 9,
+                                      child: StreamPreview(
+                                          channel: widget.channel),
+                                    );
+                                  } else {
+                                    return Container();
+                                  }
+                                },
+                              ),
+                            ],
+                          );
+                        },
+                      );
+                    } else {
+                      // landscape
+                      return Row(
+                        children: [
+                          Consumer<LayoutModel>(
+                            builder: (context, layoutModel, child) {
+                              if (!layoutModel.isShowNotifications &&
+                                  !layoutModel.isShowPreview) {
+                                return Container();
+                              }
+                              return ResizableWidget(
+                                resizable: !layoutModel.locked,
+                                height: layoutModel.panelHeight,
+                                width: layoutModel.panelWidth,
+                                onResizeHeight: (height) {
+                                  layoutModel.panelHeight = height;
+                                },
+                                onResizeWidth: (width) {
+                                  layoutModel.panelWidth = width;
+                                },
+                                child: Consumer<LayoutModel>(
+                                  builder: (context, layoutModel, child) {
+                                    if (layoutModel.isShowNotifications) {
+                                      return const ActivityFeedPanelWidget();
+                                    } else if (layoutModel.isShowPreview) {
+                                      return StreamPreview(
+                                          channel: widget.channel);
+                                    } else {
+                                      return Container();
+                                    }
+                                  },
+                                ),
+                              );
+                            },
+                          ),
+                          Expanded(
+                            child: Column(
+                              children: [
+                                Expanded(
+                                  child: DiscoWidget(
                                     isEnabled: widget.isDiscoModeEnabled,
                                     child: ChatPanelWidget(
-                                        channel: widget.channel))),
-
-                            Consumer<LayoutModel>(
-                                builder: (context, layoutModel, child) {
-                              if (layoutModel.isShowNotifications) {
-                                return ResizableWidget(
-                                    resizable: !layoutModel.locked,
-                                    height: layoutModel.panelHeight,
-                                    width: layoutModel.panelWidth,
-                                    onResizeHeight: (height) {
-                                      layoutModel.panelHeight = height;
-                                    },
-                                    onResizeWidth: (width) {
-                                      layoutModel.panelWidth = width;
-                                    },
-                                    child: const ActivityFeedPanelWidget());
-                              } else if (layoutModel.isShowPreview) {
-                                return AspectRatio(
-                                    aspectRatio: 16 / 9,
-                                    child:
-                                        StreamPreview(channel: widget.channel));
-                              } else {
-                                return Container();
-                              }
-                            }),
-                          ]);
-                    });
-                  } else {
-                    // landscape
-                    return Row(children: [
-                      Consumer<LayoutModel>(
-                          builder: (context, layoutModel, child) {
-                        if (!layoutModel.isShowNotifications &&
-                            !layoutModel.isShowPreview) {
-                          return Container();
-                        }
-                        return ResizableWidget(
-                            resizable: !layoutModel.locked,
-                            height: layoutModel.panelHeight,
-                            width: layoutModel.panelWidth,
-                            onResizeHeight: (height) {
-                              layoutModel.panelHeight = height;
-                            },
-                            onResizeWidth: (width) {
-                              layoutModel.panelWidth = width;
-                            },
-                            child: Consumer<LayoutModel>(
-                                builder: (context, layoutModel, child) {
-                              if (layoutModel.isShowNotifications) {
-                                return const ActivityFeedPanelWidget();
-                              } else if (layoutModel.isShowPreview) {
-                                return StreamPreview(channel: widget.channel);
-                              } else {
-                                return Container();
-                              }
-                            }));
-                      }),
-                      Expanded(
-                          child: Column(children: [
-                        Expanded(
-                            child: DiscoWidget(
-                                isEnabled: widget.isDiscoModeEnabled,
-                                child:
-                                    ChatPanelWidget(channel: widget.channel))),
-                        chatPanelFooter,
-                      ]))
-                    ]);
-                  }
-                }),
+                                        channel: widget.channel),
+                                  ),
+                                ),
+                                chatPanelFooter,
+                              ],
+                            ),
+                          ),
+                        ],
+                      );
+                    }
+                  },
+                ),
               ),
             ),
           );
-        }));
+        },
+      ),
+    );
   }
 }


### PR DESCRIPTION
This fixes and overflow when swapping between the picker and the keyboard. Also fixes when an emote is too large (will be changed later).

This also changes the emote picker to look more like the old one and twitch's. The old one in our app.
![IMG_74AADF11CE23-1](https://github.com/muxable/rtchat/assets/100245448/798a07ea-ac30-4c5c-a1b2-f7a9ad398b2d)

My new implementation.
![IMG_3271](https://github.com/muxable/rtchat/assets/100245448/f165d5f5-d986-4ffe-aebf-5b9d7fbfc366)

Twitch's implementation.
![IMG_3271](https://github.com/muxable/rtchat/assets/100245448/227e96af-2b23-456a-b0b7-2c343d283430)

Lemme know what I can tweak to make it better since this isn't 100% complete 
