### PR TITLE
fix: dupe translation string

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -75,7 +75,7 @@
   },
   "activityFeed": "Activity feed",
   "@activityFeed": {
-    "description": "Tooltip text for a button that shows the activity feed"
+    "description": "Header for the activity feed settings page and tooltip text for a button that shows the activity feed"
   },
   "streamOnline": "Stream online at {date}, {time}",
   "@streamOnline": {
@@ -220,10 +220,6 @@
   "or": "or",
   "@or": {
     "description": "Text label that separates two options"
-  },
-  "activityFeed": "Activity feed",
-  "@activityFeed": {
-    "description": "Header for the activity feed settings page"
   },
   "clearCookies": "Clear cookies",
   "@clearCookies": {

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -46,7 +46,6 @@
   "invalidUrlErrorText": "Isso não parece ser um URL válido",
   "duplicateUrlErrorText": "Este link já existe",
   "or": "ou",
-  "activityFeed": "Feed de atividade",
   "clearCookies": "Limpar cookies",
   "disabled": "Desabilitado",
   "twitchActivityFeed": "Feed de atividade da Twitch",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -46,7 +46,6 @@
   "invalidUrlErrorText": "這似乎不是有效的網址",
   "duplicateUrlErrorText": "此連結已存在",
   "or": "或",
-  "activityFeed": "活動動態",
   "clearCookies": "清除 Cookies",
   "disabled": "停用",
   "twitchActivityFeed": "Twitch 活動動態",


### PR DESCRIPTION
This translation string is a dupe, otherwise since it appears in two different screen I can rename it to make it easily distinguishable.