### PR TITLE
Add readiness & liveness status check handlers

### DIFF
--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -127,6 +127,18 @@ func main() {
 		}
 		w.Write([]byte((72*time.Hour - time.Since(start)).String()))
 	}))
+	http.Handle("/readiness", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isListening.Load() || time.Since(start) > 72*time.Hour {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+	http.Handle("/liveness", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
 
 	go func() {
 		zap.L().Info("starting http server")


### PR DESCRIPTION
This PR adds readiness and liveness status check handlers to the agent, which help ensure the health of the application in 
 Kubernetes.

Changes Made:
* Added` /readiness` endpoint to check if the service is ready.
* Added `/liveness` endpoint to check if the service is running.
* Kept the existing root endpoint handler. (not sure if this is OK)

It should work in Kubernetes like,
```yaml
        readinessProbe:
          httpGet:
            path: /readiness
            port: 8080
          initialDelaySeconds: 5
          periodSeconds: 10
        livenessProbe:
          httpGet:
            path: /liveness
            port: 8080
          initialDelaySeconds: 5
          periodSeconds: 10
```

**Sadly I cannot test this because it needs some Google Cloud auth:**
```
2024-07-29T23:01:12.775+0300    FATAL   cmd/main.go:92  failed to create firestore client       {"error": "google: could not find default credentials. See https://cloud.google.com/docs/authentication/external/set-up-adc for more information"}
```