### PR TITLE
fix: autofill emotes while typing

### DIFF
--- a/lib/components/autocomplete.dart
+++ b/lib/components/autocomplete.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:rtchat/components/emote_text_editing_controller.dart';
 import 'package:rtchat/components/image/resilient_network_image.dart';
 import 'package:rtchat/models/channels.dart';
 import 'package:rtchat/models/chat_mode.dart';
@@ -33,7 +34,7 @@ extension _AutocompleteModeExtension on _AutocompleteMode {
 }
 
 class AutocompleteWidget extends StatefulWidget {
-  final TextEditingController controller;
+  final EmoteTextEditingController controller;
   final Function(String) onSend;
   final Channel channel;
 
@@ -101,10 +102,8 @@ class _AutocompleteWidgetState extends State<AutocompleteWidget> {
                   child: IconButton(
                       tooltip: emote.code,
                       onPressed: () {
-                        widget.controller.text = "${text.substring(
-                          0,
-                          text.length - lastToken.length,
-                        )}${emote.code} ";
+                        widget.controller.addEmote(emote);
+
                         // move cursor position
                         widget.controller.selection =
                             TextSelection.fromPosition(TextPosition(

--- a/lib/components/emote_text_editing_controller.dart
+++ b/lib/components/emote_text_editing_controller.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:rtchat/models/messages/twitch/emote.dart';
+
+class EmoteTextEditingController extends TextEditingController {
+  final List<Emote> emotes = [];
+
+  void addEmote(Emote emote) {
+    // Append emote code to the existing text
+    emotes.add(emote);
+
+    final newText = '$text ${emote.code} ';
+    text = newText.trim(); // Ensure no extra spaces
+    notifyListeners();
+  }
+
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    required bool withComposing,
+  }) {
+    final text = this.text;
+    final textSpans = <InlineSpan>[];
+
+    final words = text.split(' ');
+    for (var word in words) {
+      final emote = emotes.firstWhere(
+        (emote) => emote.code == word,
+        orElse: () =>
+            Emote(provider: '', category: '', id: '', code: '', imageUrl: ''),
+      );
+
+      if (emote.code.isNotEmpty) {
+        if (emote.imageUrl.isNotEmpty) {
+          textSpans.add(WidgetSpan(
+            alignment: PlaceholderAlignment.middle,
+            child: Image.network(
+              emote.imageUrl,
+              width: 24,
+              height: 24,
+            ),
+          ));
+        }
+      } else {
+        textSpans.add(TextSpan(
+          text: '$word ',
+          style: style,
+        ));
+      }
+    }
+
+    return TextSpan(children: textSpans, style: style);
+  }
+}

--- a/lib/components/message_input.dart
+++ b/lib/components/message_input.dart
@@ -7,6 +7,7 @@ import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:provider/provider.dart';
 import 'package:rtchat/components/autocomplete.dart';
 import 'package:rtchat/components/emote_picker.dart';
+import 'package:rtchat/components/emote_text_editing_controller.dart';
 import 'package:rtchat/components/image/resilient_network_image.dart';
 import 'package:rtchat/models/adapters/actions.dart';
 import 'package:rtchat/models/channels.dart';
@@ -38,7 +39,7 @@ const _greyscale = ColorFilter.matrix([
 ]);
 
 class _MessageInputWidgetState extends State<MessageInputWidget> {
-  final _textEditingController = TextEditingController();
+  final _textEditingController = EmoteTextEditingController();
   final _chatInputFocusNode = FocusNode();
   var _isEmotePickerVisible = false;
   var _isKeyboardVisible = false;
@@ -135,8 +136,10 @@ class _MessageInputWidgetState extends State<MessageInputWidget> {
             });
             return;
           }
-          _textEditingController.text =
-              "${_textEditingController.text} ${emote.code}";
+
+          debugPrint("Emote Url : ${emote.imageUrl}");
+
+          _textEditingController.addEmote(emote);
         });
   }
 


### PR DESCRIPTION
Incomplete need another pair of eyes on this.

![Screenshot 2024-07-31 at 9 58 05 AM](https://github.com/user-attachments/assets/f57b45fe-dab4-4d8f-8b62-bfd684e399c8)
This is what I am attempting to do, currently the cursor jumps to the start when backspacing and not sure how to quite handle the text replacement.