### PR TITLE
fix: raid null check

### DIFF
--- a/lib/components/channel_search_bottom_sheet.dart
+++ b/lib/components/channel_search_bottom_sheet.dart
@@ -43,7 +43,7 @@ class _ChannelSearchBottomSheetWidgetState
           Row(children: [
             Expanded(
                 child: Text(
-                    _raid
+                    _raid && widget.onRaid != null
                         ? AppLocalizations.of(context)!.raidAChannel
                         : AppLocalizations.of(context)!.searchChannels,
                     style: Theme.of(context).textTheme.headlineMedium)),
@@ -90,7 +90,7 @@ class _ChannelSearchBottomSheetWidgetState
             query: _value,
             controller: widget.controller,
             onChannelSelect: (channel) {
-              if (_raid) {
+              if (_raid && widget.onRaid != null) {
                 FirebaseAnalytics.instance.logEvent(
                     name: "raid", parameters: {"channelId": channel.channelId});
                 widget.onRaid!(channel);
@@ -102,7 +102,7 @@ class _ChannelSearchBottomSheetWidgetState
               }
               Navigator.of(context).pop();
             },
-            isShowOnlyOnline: _raid,
+            isShowOnlyOnline: _raid && widget.onRaid != null,
           ))
         ],
       ),


### PR DESCRIPTION
Fixes stack trace:

```
          Fatal Exception: FlutterError
0  ???                            0x0 _ChannelSearchBottomSheetWidgetState.build.<fn> + 96 (channel_search_bottom_sheet.dart:96)
1  ???                            0x0 _ChannelSearchResultsWidgetState.build.<fn>.<fn>.<fn> + 226 (channel_search_results.dart:226)
2  ???                            0x0 _InkResponseState.handleTap + 1171 (ink_well.dart:1171)
3  ???                            0x0 GestureRecognizer.invokeCallback + 344 (recognizer.dart:344)
4  ???                            0x0 TapGestureRecognizer.handleTapUp + 652 (tap.dart:652)
5  ???                            0x0 BaseTapGestureRecognizer._checkUp + 309 (tap.dart:309)
6  ???                            0x0 BaseTapGestureRecognizer.acceptGesture + 279 (tap.dart:279)
7  ???                            0x0 GestureArenaManager.sweep + 167 (arena.dart:167)
8  ???                            0x0 GestureBinding.handleEvent + 499 (binding.dart:499)
9  ???                            0x0 GestureBinding.dispatchEvent + 475 (binding.dart:475)
```