### PR TITLE
fix: fix deprecation warning in emote_picker.dart

### DIFF
--- a/lib/components/emote_picker.dart
+++ b/lib/components/emote_picker.dart
@@ -194,7 +194,7 @@ class EmotePickerWidget extends StatelessWidget {
 
     return PopScope(
       canPop: false,
-      onPopInvoked: (bool didPop) {
+      onPopInvokedWithResult: (didPop, result) {
         onEmoteSelected(null);
       },
       child: SizedBox(


### PR DESCRIPTION
Replace the usage of the deprecated 'onPopInvoked' with 'onPopInvokedWithResult' in `lib/components/emote_picker.dart`.

* Update the callback function to match the new signature of 'onPopInvokedWithResult'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat?shareId=4a472c99-6d24-46d4-82bd-aca5359335d5).