### PR TITLE
fix: migrate @UIApplicationMain attribute to @main

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,7 +3,7 @@ import Flutter
 import UIKit
 import WebKit
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
     var sharedText = ""
     


### PR DESCRIPTION
```ios/Runner/AppDelegate.swift uses the deprecated @UIApplicationMain attribute, updating.```

https://forums.swift.org/t/se-0383-deprecate-uiapplicationmain-and-nsapplicationmain/62375
https://github.com/flutter/flutter/issues/143044