### PR TITLE
fix: analyzer warning in companion_auth.dart

### DIFF
--- a/lib/components/auth/companion_auth.dart
+++ b/lib/components/auth/companion_auth.dart
@@ -25,15 +25,16 @@ class _CompanionAuthWidgetState extends State<CompanionAuthWidget> {
   @override
   void initState() {
     super.initState();
+    final user = Provider.of<UserModel>(context, listen: false);
+    final navigator = Navigator.of(context);
     ProfilesAdapter.instance
         .getCompanionAuthToken(sessionUuid: sessionUuid)
         .then((token) async {
-      final user = Provider.of<UserModel>(context, listen: false);
       await user.signIn(token);
       if (!mounted) {
         return;
       }
-      Navigator.of(context).pop();
+      navigator.pop();
     });
   }
 


### PR DESCRIPTION
Fix the analyzer warning about using 'BuildContext' across async gaps in `lib/components/auth/companion_auth.dart`.

* Move the `Provider.of<UserModel>(context, listen: false)` call to before the async gap.
* Store the `UserModel` instance in a local variable.
* Move the `Navigator.of(context)` call to before the async gap and store it in a local variable.
* Use the local variables instead of calling `Provider.of<UserModel>(context, listen: false)` and `Navigator.of(context)` after the async gap.
* Retain the `mounted` check before calling `navigator.pop()`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat?shareId=ff920a9b-a15c-4ad8-9afd-9ae02d81b5b3).