### PR TITLE
fix: metadata lookup failure handling

### DIFF
--- a/lib/screens/settings/audio_sources.dart
+++ b/lib/screens/settings/audio_sources.dart
@@ -47,7 +47,14 @@ class _AudioSourcesScreenState extends State<AudioSourcesScreen> {
     if (_formKey.currentState!.validate()) {
       // fetch the title for the page.
       final url = _textEditingController.text;
-      final metadata = await MetadataFetch.extract(url);
+      Metadata? metadata;
+      try {
+        metadata = await MetadataFetch.extract(url);
+      } catch (e) {
+        metadata = null;
+      }
+
+      final title = metadata?.title ?? Uri.parse(url).host;
 
       if (!mounted) return;
       final model = Provider.of<AudioModel>(context, listen: false);
@@ -55,8 +62,7 @@ class _AudioSourcesScreenState extends State<AudioSourcesScreen> {
         if (!mounted) return;
         await model.showAudioPermissionDialog(context);
       }
-      await model
-          .addSource(AudioSource(metadata?.title, Uri.parse(url), false));
+      await model.addSource(AudioSource(title, Uri.parse(url), false));
 
       if (!mounted) return;
       _textEditingController.clear();


### PR DESCRIPTION
Update `add` method in `lib/screens/settings/audio_sources.dart` to handle metadata lookup failures.

* **Metadata Fetching:**
  - Wrap `MetadataFetch.extract` call with a try/catch block to handle potential exceptions.
  - Assign `null` to `metadata` if an exception occurs.
  - Use the URL hostname as the title if metadata lookup fails.

* **Audio Source Addition:**
  - Update the `addSource` method to use the title derived from metadata or URL hostname.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat?shareId=ca02a26f-092f-431a-8af6-fe22ca8bdcc6).