### PR TITLE
fix: gradle causing builds to fail

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version "7.4.0" apply false
     id "org.jetbrains.kotlin.android" version "1.9.21" apply false
     id "com.google.gms.google-services" version "4.4.0" apply false
     id "com.google.firebase.crashlytics" version "2.9.9" apply false

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -13,12 +13,18 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven {
+                url = uri("https://storage.googleapis.com/r8-releases/raw")
+            }
+        dependencies {
+            classpath("com.android.tools:r8:3.3.75")
+        }
     }
 }
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.4.0" apply false
+    id "com.android.application" version "7.3.0" apply false
     id "org.jetbrains.kotlin.android" version "1.9.21" apply false
     id "com.google.gms.google-services" version "4.4.0" apply false
     id "com.google.firebase.crashlytics" version "2.9.9" apply false

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -13,11 +13,17 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven {
+    }
+
+    buildscript {
+        repositories {
+            mavenCentral()
+            maven {
                 url = uri("https://storage.googleapis.com/r8-releases/raw")
             }
+        }
         dependencies {
-            classpath("com.android.tools:r8:3.3.75")
+            classpath("com.android.tools:r8:3.3.78")
         }
     }
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -14,18 +14,6 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
-
-    buildscript {
-        repositories {
-            mavenCentral()
-            maven {
-                url = uri("https://storage.googleapis.com/r8-releases/raw")
-            }
-        }
-        dependencies {
-            classpath("com.android.tools:r8:3.3.78")
-        }
-    }
 }
 
 plugins {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -14,6 +14,18 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+
+    buildscript {
+        repositories {
+            mavenCentral()
+            maven {
+                url = uri("https://storage.googleapis.com/r8-releases/raw")
+            }
+        }
+        dependencies {
+            classpath("com.android.tools:r8:3.3.78")
+        }
+    }
 }
 
 plugins {


### PR DESCRIPTION
Upgraded one version to fix the build failing or I could do maybe the workaround fix mentioned on https://issuetracker.google.com/issues/242308990
```┌─ Flutter Fix ────────────────────────────────────────────────────────────────────────────────────┐
│ [!] Version 7.3 of the Android Gradle Plugin (AGP) uses a version of R8 that contains a bug      │
│ which causes this error (see more info at https://issuetracker.google.com/issues/242308990).     │
│ To fix this error, update to a newer version of AGP (at least 7.4.0).                            │
│                                                                                                  │
│  The version of AGP that your project uses is likely defined in:                                 │
│ /home/runner/work/rtchat/rtchat/android/settings.gradle,                                         │
│ in the 'plugins' closure (by the number following "com.android.application").                    │
│  Alternatively, if your project was created with an older version of the templates, it is likely │
│ in the buildscript.dependencies closure of the top-level build.gradle:                           │
│ /home/runner/work/rtchat/rtchat/android/build.gradle,                                            │
│ as the number following "com.android.tools.build:gradle:".                                       │
└──────────────────────────────────────────────────────────────────────────────────────────────────┘```