### PR TITLE
fix: make _textEditingController nullable and non-final in message_input.dart

### DIFF
--- a/lib/components/message_input.dart
+++ b/lib/components/message_input.dart
@@ -148,7 +148,7 @@ const _greyscale = ColorFilter.matrix([
 ]);
 
 class _MessageInputWidgetState extends State<MessageInputWidget> {
-  late final EmoteTextEditingController _textEditingController;
+  EmoteTextEditingController? _textEditingController;
   final _chatInputFocusNode = FocusNode();
   var _isEmotePickerVisible = false;
   var _isKeyboardVisible = false;
@@ -180,13 +180,13 @@ class _MessageInputWidgetState extends State<MessageInputWidget> {
   @override
   void didUpdateWidget(MessageInputWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _textEditingController.emotes = widget.emotes;
+    _textEditingController?.emotes = widget.emotes;
   }
 
   // Handles any shared data we may receive.
   void _handleSharedData(String sharedData) {
     setState(() {
-      _textEditingController.text = sharedData;
+      _textEditingController?.text = sharedData;
     });
   }
 
@@ -194,7 +194,7 @@ class _MessageInputWidgetState extends State<MessageInputWidget> {
   void dispose() {
     keyboardSubscription.cancel();
     _chatInputFocusNode.dispose();
-    _textEditingController.dispose();
+    _textEditingController?.dispose();
     super.dispose();
   }
 
@@ -212,7 +212,7 @@ class _MessageInputWidgetState extends State<MessageInputWidget> {
       return;
     }
     setState(() {
-      _textEditingController.clear();
+      _textEditingController?.clear();
     });
     var done = false;
     await Future.wait([
@@ -269,7 +269,7 @@ class _MessageInputWidgetState extends State<MessageInputWidget> {
             if (_isKeyboardVisible)
               Flexible(
                 child: AutocompleteWidget(
-                  controller: _textEditingController,
+                  controller: _textEditingController!,
                   onSend: sendMessage,
                   channel: widget.channel,
                 ),
@@ -318,7 +318,7 @@ class _MessageInputWidgetState extends State<MessageInputWidget> {
                         color: Theme.of(context).colorScheme.primary,
                         splashRadius: 24,
                         onPressed: () =>
-                            sendMessage(_textEditingController.text),
+                            sendMessage(_textEditingController?.text ?? ''),
                       ),
                       border: InputBorder.none,
                       hintMaxLines: 1,
@@ -341,10 +341,11 @@ class _MessageInputWidgetState extends State<MessageInputWidget> {
                       return;
                     }
                     setState(() {
-                      _textEditingController.value = TextEditingValue(
+                      _textEditingController?.value = TextEditingValue(
                           text: filtered,
                           selection: TextSelection.fromPosition(TextPosition(
-                              offset: _textEditingController.text.length)));
+                              offset: _textEditingController?.text.length ??
+                                  0)));
                     });
                   },
                   onSubmitted: sendMessage,
@@ -366,11 +367,11 @@ class _MessageInputWidgetState extends State<MessageInputWidget> {
                         });
                         return;
                       }
-                      if (_textEditingController.text.isNotEmpty) {
-                        _textEditingController.text =
-                            "${_textEditingController.text} ${emote.code} ";
+                      if (_textEditingController?.text.isNotEmpty ?? false) {
+                        _textEditingController?.text =
+                            "${_textEditingController?.text} ${emote.code} ";
                       } else {
-                        _textEditingController.text = "${emote.code} ";
+                        _textEditingController?.text = "${emote.code} ";
                       }
                     })
                 : Container(),

--- a/lib/components/message_input.dart
+++ b/lib/components/message_input.dart
@@ -344,8 +344,8 @@ class _MessageInputWidgetState extends State<MessageInputWidget> {
                       _textEditingController?.value = TextEditingValue(
                           text: filtered,
                           selection: TextSelection.fromPosition(TextPosition(
-                              offset: _textEditingController?.text.length ??
-                                  0)));
+                              offset:
+                                  _textEditingController?.text.length ?? 0)));
                     });
                   },
                   onSubmitted: sendMessage,

--- a/lib/components/pinnable/reverse_refresh_indicator.dart
+++ b/lib/components/pinnable/reverse_refresh_indicator.dart
@@ -412,8 +412,7 @@ class ReverseRefreshIndicatorState extends State<ReverseRefreshIndicator>
     }
     _positionController.value =
         newValue.clamp(0.0, 1.0); // this triggers various rebuilds
-    if (_mode == _RefreshIndicatorMode.drag &&
-        _valueColor.value!.a == 0xFF) {
+    if (_mode == _RefreshIndicatorMode.drag && _valueColor.value!.a == 0xFF) {
       _mode = _RefreshIndicatorMode.armed;
     }
   }


### PR DESCRIPTION
Make `_textEditingController` nullable and non-final in `message_input.dart` and handle all the null check cases.

* Change `_textEditingController` to nullable by updating its type to `EmoteTextEditingController?`.
* Add null checks before accessing `_textEditingController` in `didUpdateWidget`, `_handleSharedData`, `dispose`, and `sendMessage` methods.
* Update the `TextField` widget in the `build` method to handle the case when `_textEditingController` is null.
* Use null-aware operators to safely access `_textEditingController` properties and methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/rtchat/pull/1331?shareId=b978c8c3-fec7-4ac3-91d4-f644eb539b9b).